### PR TITLE
feat: 룸 탐색 기능을 구현한다.

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
@@ -2,17 +2,14 @@ package com.digginroom.digginroom.controller;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+import com.digginroom.digginroom.controller.dto.ErrorResponse;
+import com.digginroom.digginroom.exception.DigginRoomException;
 import java.time.LocalDateTime;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
-
-import com.digginroom.digginroom.controller.dto.ErrorResponse;
-import com.digginroom.digginroom.exception.DigginRoomException;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice

--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -1,0 +1,19 @@
+package com.digginroom.digginroom.controller;
+
+import com.digginroom.digginroom.controller.dto.RoomResponse;
+import com.digginroom.digginroom.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @GetMapping("/room")
+    public RoomResponse showRandomRoom() {
+        return roomService.pickRandom();
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/RoomResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/RoomResponse.java
@@ -1,0 +1,4 @@
+package com.digginroom.digginroom.controller.dto;
+
+public record RoomResponse(Long roomId, String videoId) {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -17,21 +17,12 @@ public class MediaSource {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private MediaType mediaType;
     private String identifier;
 
-    public MediaSource(final MediaType mediaType, final String identifier) {
-        validateNotNull(mediaType);
+    public MediaSource(final String identifier) {
         validateNotNull(identifier);
         validateNotBlank(identifier);
-        this.mediaType = mediaType;
         this.identifier = identifier;
-    }
-
-    private void validateNotNull(final MediaType mediaType) {
-        if (Objects.isNull(mediaType)) {
-            throw new IllegalArgumentException("미디어 타입이 지정되지 않았습니다");
-        }
     }
 
     private void validateNotNull(final String identifier) {

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -1,5 +1,7 @@
 package com.digginroom.digginroom.domain;
 
+import static com.digginroom.digginroom.exception.MediaSourceException.NoIdentifierException;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,13 +29,13 @@ public class MediaSource {
 
     private void validateNotNull(final String identifier) {
         if (Objects.isNull(identifier)) {
-            throw new IllegalArgumentException("식별자가 지정되지 않았습니다");
+            throw new NoIdentifierException();
         }
     }
 
     private void validateNotBlank(final String identifier) {
         if (identifier.isBlank()) {
-            throw new IllegalArgumentException("식별자는 공백일 수 없습니다");
+            throw new NoIdentifierException();
         }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -8,11 +8,9 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Entity
-@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MediaSource {
 

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -4,13 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.ToString.Exclude;
 
 @Getter
 @Entity
@@ -23,9 +21,6 @@ public class MediaSource {
     private Long id;
     private MediaType mediaType;
     private String identifier;
-    @Exclude
-    @ManyToOne
-    private Room room;
 
     public MediaSource(final MediaType mediaType, final String identifier) {
         validateNotNull(mediaType);
@@ -51,9 +46,5 @@ public class MediaSource {
         if (identifier.isBlank()) {
             throw new IllegalArgumentException("식별자는 공백일 수 없습니다");
         }
-    }
-
-    public void setRoom(final Room room) {
-        this.room = room;
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -1,0 +1,37 @@
+package com.digginroom.digginroom.domain;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class MediaSource {
+
+    private final MediaType mediaType;
+    private final String identifier;
+
+    public MediaSource(final MediaType mediaType, final String identifier) {
+        validateNotNull(mediaType);
+        validateNotNull(identifier);
+        validateNotBlank(identifier);
+        this.mediaType = mediaType;
+        this.identifier = identifier;
+    }
+
+    private void validateNotNull(final MediaType mediaType) {
+        if (Objects.isNull(mediaType)) {
+            throw new IllegalArgumentException("미디어 타입이 지정되지 않았습니다");
+        }
+    }
+
+    private void validateNotNull(final String identifier) {
+        if (Objects.isNull(identifier)) {
+            throw new IllegalArgumentException("식별자가 지정되지 않았습니다");
+        }
+    }
+
+    private void validateNotBlank(final String identifier) {
+        if (identifier.isBlank()) {
+            throw new IllegalArgumentException("식별자는 공백일 수 없습니다");
+        }
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -1,13 +1,27 @@
 package com.digginroom.digginroom.domain;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import java.util.Objects;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MediaSource {
 
-    private final MediaType mediaType;
-    private final String identifier;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private MediaType mediaType;
+    private String identifier;
+    @ManyToOne
+    private Room room;
 
     public MediaSource(final MediaType mediaType, final String identifier) {
         validateNotNull(mediaType);

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaSource.java
@@ -9,9 +9,12 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.ToString.Exclude;
 
 @Getter
 @Entity
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MediaSource {
 
@@ -20,6 +23,7 @@ public class MediaSource {
     private Long id;
     private MediaType mediaType;
     private String identifier;
+    @Exclude
     @ManyToOne
     private Room room;
 
@@ -47,5 +51,9 @@ public class MediaSource {
         if (identifier.isBlank()) {
             throw new IllegalArgumentException("식별자는 공백일 수 없습니다");
         }
+    }
+
+    public void setRoom(final Room room) {
+        this.room = room;
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaType.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaType.java
@@ -1,6 +1,0 @@
-package com.digginroom.digginroom.domain;
-
-public enum MediaType {
-
-    YOUTUBE
-}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/MediaType.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/MediaType.java
@@ -1,0 +1,6 @@
+package com.digginroom.digginroom.domain;
+
+public enum MediaType {
+
+    YOUTUBE
+}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
@@ -1,0 +1,36 @@
+package com.digginroom.digginroom.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.PERSIST)
+    private List<MediaSource> mediaSources;
+
+    public Room(final List<MediaSource> mediaSources) {
+        validateNotEmpty(mediaSources);
+        this.mediaSources = mediaSources;
+    }
+
+    private void validateNotEmpty(final List<MediaSource> mediaSources) {
+        if (mediaSources.size() == 0) {
+            throw new IllegalArgumentException("룸의 미디어 소스는 비어있을 수 없습니다");
+        }
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
@@ -5,8 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,24 +22,17 @@ public class Room {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "room", cascade = CascadeType.PERSIST)
-    private List<MediaSource> mediaSources;
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    private MediaSource mediaSource;
 
-    public Room(final List<MediaSource> mediaSources) {
-        validateNotEmpty(mediaSources);
-        this.mediaSources = mediaSources;
-        bindRooms(mediaSources);
+    public Room(final MediaSource mediaSource) {
+        validateNotNull(mediaSource);
+        this.mediaSource = mediaSource;
     }
 
-    private void bindRooms(final List<MediaSource> mediaSources) {
-        for (MediaSource mediaSource : mediaSources) {
-            mediaSource.setRoom(this);
-        }
-    }
-
-    private void validateNotEmpty(final List<MediaSource> mediaSources) {
-        if (mediaSources.size() == 0) {
-            throw new IllegalArgumentException("룸의 미디어 소스는 비어있을 수 없습니다");
+    private void validateNotNull(final MediaSource mediaSource) {
+        if (Objects.isNull(mediaSource)) {
+            throw new IllegalArgumentException("미디어 소스가 있어야 합니다");
         }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
@@ -10,9 +10,11 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Entity
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Room {
 
@@ -26,6 +28,13 @@ public class Room {
     public Room(final List<MediaSource> mediaSources) {
         validateNotEmpty(mediaSources);
         this.mediaSources = mediaSources;
+        bindRooms(mediaSources);
+    }
+
+    private void bindRooms(final List<MediaSource> mediaSources) {
+        for (MediaSource mediaSource : mediaSources) {
+            mediaSource.setRoom(this);
+        }
     }
 
     private void validateNotEmpty(final List<MediaSource> mediaSources) {

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
@@ -10,11 +10,9 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Entity
-@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Room {
 

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Room.java
@@ -1,5 +1,7 @@
 package com.digginroom.digginroom.domain;
 
+import static com.digginroom.digginroom.exception.RoomException.NoMediaSourceException;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -30,7 +32,7 @@ public class Room {
 
     private void validateNotNull(final MediaSource mediaSource) {
         if (Objects.isNull(mediaSource)) {
-            throw new IllegalArgumentException("미디어 소스가 있어야 합니다");
+            throw new NoMediaSourceException();
         }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/exception/MediaSourceException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/MediaSourceException.java
@@ -1,0 +1,17 @@
+package com.digginroom.digginroom.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class MediaSourceException extends DigginRoomException {
+
+    public MediaSourceException(final String message, final HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+
+    public static class NoIdentifierException extends RoomException {
+
+        public NoIdentifierException() {
+            super("미디어 소스 식별자는 필수입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
@@ -21,4 +21,11 @@ public abstract class RoomException extends DigginRoomException {
             super("더 이상 룸이 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    public static class NoMediaSourceException extends RoomException {
+
+        public NoMediaSourceException() {
+            super("룸은 미디어소스가 필수입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
@@ -8,10 +8,17 @@ public abstract class RoomException extends DigginRoomException {
         super(message, httpStatus);
     }
 
-    public static class NotFound extends RoomException {
+    public static class NotFoundException extends RoomException {
 
-        public NotFound(final Long id) {
+        public NotFoundException(final Long id) {
             super(id + "에 해당하는 룸이 없습니다", HttpStatus.NOT_FOUND);
+        }
+    }
+
+    public static class EmptyException extends RoomException {
+
+        public EmptyException() {
+            super("더 이상 룸이 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/repository/RoomRepository.java
+++ b/backend/src/main/java/com/digginroom/digginroom/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.digginroom.digginroom.repository;
+
+import com.digginroom.digginroom.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -4,8 +4,6 @@ import com.digginroom.digginroom.controller.dto.RoomResponse;
 import com.digginroom.digginroom.domain.Room;
 import com.digginroom.digginroom.exception.RoomException.EmptyException;
 import com.digginroom.digginroom.repository.RoomRepository;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,17 +19,6 @@ public class RoomService {
     private final RoomRepository roomRepository;
 
     public RoomResponse pickRandom() {
-        List<Room> rooms = roomRepository.findAll();
-        Collections.shuffle(rooms);
-
-        Room pickedRoom = rooms.stream()
-                .findFirst()
-                .orElseThrow(EmptyException::new);
-
-        return new RoomResponse(pickedRoom.getId(), pickedRoom.getMediaSource().getIdentifier());
-    }
-
-    public Room pickRandomByPage() {
         int count = Math.toIntExact(roomRepository.count());
 
         Page<Room> randomizedPage = roomRepository.findAll(
@@ -39,9 +26,11 @@ public class RoomService {
                         .withPage(ThreadLocalRandom.current().nextInt(count))
         );
 
-        return randomizedPage.getContent()
+        Room pickedRoom = randomizedPage.getContent()
                 .stream()
                 .findFirst()
                 .orElseThrow(EmptyException::new);
+
+        return new RoomResponse(pickedRoom.getId(), pickedRoom.getMediaSource().getIdentifier());
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -1,0 +1,40 @@
+package com.digginroom.digginroom.service;
+
+import com.digginroom.digginroom.domain.Room;
+import com.digginroom.digginroom.repository.RoomRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+
+    @Transactional
+    public Room pickRandom() {
+        List<Room> rooms = roomRepository.findAll();
+
+        Collections.shuffle(rooms);
+
+        return rooms.get(0);
+    }
+
+    @Transactional
+    public Room pickRandomByPage() {
+        int count = Long.valueOf(roomRepository.count()).intValue();
+
+        Pageable pageable = Pageable.ofSize(1)
+                .withPage(ThreadLocalRandom.current().nextInt(count));
+
+        Page<Room> randomizedPage = roomRepository.findAll(pageable);
+
+        return randomizedPage.getContent().get(0);
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -15,11 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RoomService {
 
     private final RoomRepository roomRepository;
 
-    @Transactional(readOnly = true)
     public RoomResponse pickRandom() {
         List<Room> rooms = roomRepository.findAll();
         Collections.shuffle(rooms);
@@ -31,7 +31,6 @@ public class RoomService {
         return new RoomResponse(pickedRoom.getId(), pickedRoom.getMediaSource().getIdentifier());
     }
 
-    @Transactional(readOnly = true)
     public Room pickRandomByPage() {
         int count = Math.toIntExact(roomRepository.count());
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -19,7 +19,7 @@ public class RoomService {
 
     private final RoomRepository roomRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public RoomResponse pickRandom() {
         List<Room> rooms = roomRepository.findAll();
         Collections.shuffle(rooms);
@@ -31,7 +31,7 @@ public class RoomService {
         return new RoomResponse(pickedRoom.getId(), pickedRoom.getMediaSource().getIdentifier());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Room pickRandomByPage() {
         int count = Math.toIntExact(roomRepository.count());
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -1,5 +1,6 @@
 package com.digginroom.digginroom.service;
 
+import com.digginroom.digginroom.controller.dto.RoomResponse;
 import com.digginroom.digginroom.domain.Room;
 import com.digginroom.digginroom.repository.RoomRepository;
 import java.util.Collections;
@@ -18,12 +19,14 @@ public class RoomService {
     private final RoomRepository roomRepository;
 
     @Transactional
-    public Room pickRandom() {
+    public RoomResponse pickRandom() {
         List<Room> rooms = roomRepository.findAll();
-
         Collections.shuffle(rooms);
+        Room pickedRoom = rooms.stream()
+                .findFirst()
+                .orElseThrow();
 
-        return rooms.get(0);
+        return new RoomResponse(pickedRoom.getId(), pickedRoom.getMediaSource().getIdentifier());
     }
 
     @Transactional

--- a/backend/src/test/java/com/digginroom/digginroom/domain/MediaSourceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/MediaSourceTest.java
@@ -2,6 +2,7 @@ package com.digginroom.digginroom.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.digginroom.digginroom.exception.MediaSourceException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -13,14 +14,12 @@ class MediaSourceTest {
     @Test
     void 식별자는_비어선_안된다() {
         assertThatThrownBy(() -> new MediaSource(null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("식별자가 지정되지 않았습니다");
+                .isInstanceOf(MediaSourceException.NoIdentifierException.class);
     }
 
     @Test
     void 식별자는_공백일_수_없다() {
         assertThatThrownBy(() -> new MediaSource(""))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("식별자는 공백일 수 없습니다");
+                .isInstanceOf(MediaSourceException.NoIdentifierException.class);
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/domain/MediaSourceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/MediaSourceTest.java
@@ -10,24 +10,16 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class MediaSourceTest {
 
-    // TODO: 2023/07/17 추후 커스텀 예외로 변경
-    @Test
-    void 미디어_타입은_비어선_안된다() {
-        assertThatThrownBy(() -> new MediaSource(null, "lQcnNPqy2Ww"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("미디어 타입이 지정되지 않았습니다");
-    }
-
     @Test
     void 식별자는_비어선_안된다() {
-        assertThatThrownBy(() -> new MediaSource(MediaType.YOUTUBE, null))
+        assertThatThrownBy(() -> new MediaSource(null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("식별자가 지정되지 않았습니다");
     }
 
     @Test
     void 식별자는_공백일_수_없다() {
-        assertThatThrownBy(() -> new MediaSource(MediaType.YOUTUBE, ""))
+        assertThatThrownBy(() -> new MediaSource(""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("식별자는 공백일 수 없습니다");
     }

--- a/backend/src/test/java/com/digginroom/digginroom/domain/MediaSourceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/MediaSourceTest.java
@@ -1,0 +1,34 @@
+package com.digginroom.digginroom.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MediaSourceTest {
+
+    // TODO: 2023/07/17 추후 커스텀 예외로 변경
+    @Test
+    void 미디어_타입은_비어선_안된다() {
+        assertThatThrownBy(() -> new MediaSource(null, "lQcnNPqy2Ww"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("미디어 타입이 지정되지 않았습니다");
+    }
+
+    @Test
+    void 식별자는_비어선_안된다() {
+        assertThatThrownBy(() -> new MediaSource(MediaType.YOUTUBE, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("식별자가 지정되지 않았습니다");
+    }
+
+    @Test
+    void 식별자는_공백일_수_없다() {
+        assertThatThrownBy(() -> new MediaSource(MediaType.YOUTUBE, ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("식별자는 공백일 수 없습니다");
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/domain/RoomTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/RoomTest.java
@@ -1,0 +1,19 @@
+package com.digginroom.digginroom.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RoomTest {
+
+    @Test
+    void 미디어소스는_필수다() {
+        assertThatThrownBy(() -> new Room(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("미디어 소스가 있어야 합니다");
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/domain/RoomTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/RoomTest.java
@@ -2,6 +2,7 @@ package com.digginroom.digginroom.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.digginroom.digginroom.exception.RoomException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,6 @@ class RoomTest {
     @Test
     void 미디어소스는_필수다() {
         assertThatThrownBy(() -> new Room(null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("미디어 소스가 있어야 합니다");
+                .isInstanceOf(RoomException.NoMediaSourceException.class);
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/repository/RoomRepositoryTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/repository/RoomRepositoryTest.java
@@ -3,7 +3,6 @@ package com.digginroom.digginroom.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.digginroom.digginroom.domain.MediaSource;
-import com.digginroom.digginroom.domain.MediaType;
 import com.digginroom.digginroom.domain.Room;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -24,7 +23,7 @@ class RoomRepositoryTest {
 
     @Test
     void 룸_저장_시_미디어_소스도_같아_저장된다() {
-        Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
+        Room 나무 = new Room(new MediaSource("lQcnNPqy2Ww"));
 
         roomRepository.save(나무);
 

--- a/backend/src/test/java/com/digginroom/digginroom/repository/RoomRepositoryTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/repository/RoomRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.digginroom.digginroom.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.digginroom.digginroom.domain.MediaSource;
+import com.digginroom.digginroom.domain.MediaType;
+import com.digginroom.digginroom.domain.Room;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class RoomRepositoryTest {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Test
+    void 룸_저장_시_미디어_소스도_같아_저장된다() {
+        Room 나무 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww")));
+
+        roomRepository.save(나무);
+
+        assertThat(나무.getMediaSources().get(0).getId()).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/repository/RoomRepositoryTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/repository/RoomRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.digginroom.digginroom.domain.MediaSource;
 import com.digginroom.digginroom.domain.MediaType;
 import com.digginroom.digginroom.domain.Room;
-import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -25,10 +24,10 @@ class RoomRepositoryTest {
 
     @Test
     void 룸_저장_시_미디어_소스도_같아_저장된다() {
-        Room 나무 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww")));
+        Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
 
         roomRepository.save(나무);
 
-        assertThat(나무.getMediaSources().get(0).getId()).isNotNull();
+        assertThat(나무.getMediaSource().getId()).isNotNull();
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -6,7 +6,6 @@ import com.digginroom.digginroom.domain.MediaSource;
 import com.digginroom.digginroom.domain.MediaType;
 import com.digginroom.digginroom.domain.Room;
 import com.digginroom.digginroom.repository.RoomRepository;
-import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -28,8 +27,8 @@ class RoomServiceTest {
 
     @Test
     void 여러_룸_중_랜덤으로_하나를_선택한다() {
-        Room 나무 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww")));
-        Room 가까운듯먼그대여 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc")));
+        Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
+        Room 가까운듯먼그대여 = new Room(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc"));
         roomRepository.save(나무);
         roomRepository.save(가까운듯먼그대여);
 
@@ -40,8 +39,8 @@ class RoomServiceTest {
 
     @Test
     void 페이징을_사용하여_여러_룸_중_랜덤으로_하나를_선택한다() {
-        Room 나무 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww")));
-        Room 가까운듯먼그대여 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc")));
+        Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
+        Room 가까운듯먼그대여 = new Room(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc"));
         roomRepository.save(나무);
         roomRepository.save(가까운듯먼그대여);
 

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -3,7 +3,6 @@ package com.digginroom.digginroom.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.digginroom.digginroom.domain.MediaSource;
-import com.digginroom.digginroom.domain.MediaType;
 import com.digginroom.digginroom.domain.Room;
 import com.digginroom.digginroom.repository.RoomRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -27,8 +26,8 @@ class RoomServiceTest {
 
     @Test
     void 페이징을_사용하여_여러_룸_중_랜덤으로_하나를_선택한다() {
-        Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
-        Room 가까운듯먼그대여 = new Room(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc"));
+        Room 나무 = new Room(new MediaSource("lQcnNPqy2Ww"));
+        Room 가까운듯먼그대여 = new Room(new MediaSource("2VkWaOOF4Rc"));
         roomRepository.save(나무);
         roomRepository.save(가까운듯먼그대여);
 

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -26,25 +26,13 @@ class RoomServiceTest {
     private RoomService roomService;
 
     @Test
-    void 여러_룸_중_랜덤으로_하나를_선택한다() {
-        Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
-        Room 가까운듯먼그대여 = new Room(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc"));
-        roomRepository.save(나무);
-        roomRepository.save(가까운듯먼그대여);
-
-        final var pickedRoom = roomService.pickRandom();
-
-        assertThat(pickedRoom).isNotNull();
-    }
-
-    @Test
     void 페이징을_사용하여_여러_룸_중_랜덤으로_하나를_선택한다() {
         Room 나무 = new Room(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww"));
         Room 가까운듯먼그대여 = new Room(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc"));
         roomRepository.save(나무);
         roomRepository.save(가까운듯먼그대여);
 
-        final var pickedRoom = roomService.pickRandomByPage();
+        final var pickedRoom = roomService.pickRandom();
 
         assertThat(pickedRoom).isNotNull();
     }

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -1,0 +1,52 @@
+package com.digginroom.digginroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.digginroom.digginroom.domain.MediaSource;
+import com.digginroom.digginroom.domain.MediaType;
+import com.digginroom.digginroom.domain.Room;
+import com.digginroom.digginroom.repository.RoomRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class RoomServiceTest {
+
+    @Autowired
+    private RoomRepository roomRepository;
+    @Autowired
+    private RoomService roomService;
+
+    @Test
+    void 여러_룸_중_랜덤으로_하나를_선택한다() {
+        Room 나무 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww")));
+        Room 가까운듯먼그대여 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc")));
+        roomRepository.save(나무);
+        roomRepository.save(가까운듯먼그대여);
+
+        final var pickedRoom = roomService.pickRandom();
+
+        assertThat(pickedRoom).isNotNull();
+    }
+
+    @Test
+    void 페이징을_사용하여_여러_룸_중_랜덤으로_하나를_선택한다() {
+        Room 나무 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "lQcnNPqy2Ww")));
+        Room 가까운듯먼그대여 = new Room(List.of(new MediaSource(MediaType.YOUTUBE, "2VkWaOOF4Rc")));
+        roomRepository.save(나무);
+        roomRepository.save(가까운듯먼그대여);
+
+        final var pickedRoom = roomService.pickRandomByPage();
+
+        assertThat(pickedRoom).isNotNull();
+    }
+}


### PR DESCRIPTION
## 관련 이슈번호
- #31 

## 작업 사항
- 랜덤한 룸 탐색 기능 구현
- 룸이 아예 없을 시 500 에러 반환
- 작업 내용 테스트 코드 작성

## 기타 사항

### 랜덤 방법을 선택해야 합니다
  - full-scan을 통해 모든 룸 조회 후, 랜덤으로 **하나** 선택
    - 구현과 코드가 간단.
  - 페이징을 통한 랜덤 룸 **하나** 선택
    - 성능을 조금 고려한 선택
