### PR TITLE
feat: 세부 예외 처리 및 Rolling 을 구현한다. 

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -36,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Logs ###
+log/

--- a/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.digginroom.digginroom.controller;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.digginroom.digginroom.controller.dto.ErrorResponse;
 import com.digginroom.digginroom.exception.DigginRoomException;
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
@@ -19,15 +21,17 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ErrorResponse> noHandlerFoundException() {
+    public ResponseEntity<ErrorResponse> handleNoHandlerFoundException() {
         return ResponseEntity
                 .status(NOT_FOUND)
                 .body(new ErrorResponse(LocalDateTime.now(), "리소스를 찾을 수 없습니다."));
     }
 
     @ExceptionHandler(DigginRoomException.class)
-    public ResponseEntity<ErrorResponse> digginRoomException(final DigginRoomException e) {
-        log.info(e.getMessage());
+    public ResponseEntity<ErrorResponse> handleDigginRoomException(final DigginRoomException e) {
+        if (e.getHttpStatus() == INTERNAL_SERVER_ERROR) {
+            log.error(e.getMessage());
+        }
 
         return ResponseEntity
                 .status(e.getHttpStatus())
@@ -36,12 +40,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(final MethodArgumentNotValidException e) {
-        log.info(e.getMessage());
-
         String message = e.getFieldErrors().stream()
-                .findFirst()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
-                .orElse("");
+                .collect(Collectors.joining(", "));
 
         return ResponseEntity
                 .status(BAD_REQUEST)

--- a/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
@@ -20,6 +20,15 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(final Exception e) {
+        log.error(e.getMessage(), e);
+
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(LocalDateTime.now(), "예상하지 못한 예외가 발생했습니다.(☎ 01049245690)"));
+    }
+
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoHandlerFoundException() {
         return ResponseEntity

--- a/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
@@ -11,7 +11,13 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -20,7 +26,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler({Exception.class, BindException.class})
     public ResponseEntity<ErrorResponse> handleUnexpectedException(final Exception e) {
         log.error(e.getMessage(), e);
 
@@ -56,5 +62,46 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(BAD_REQUEST)
                 .body(new ErrorResponse(LocalDateTime.now(), message));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(
+            final HttpRequestMethodNotSupportedException e
+    ) {
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(new ErrorResponse(LocalDateTime.now(), "HTTP 메서드를 확인해주세요."));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException() {
+        return ResponseEntity
+                .status(BAD_REQUEST)
+                .body(new ErrorResponse(LocalDateTime.now(), "요청 페이로드를 확인해주세요."));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            final MissingServletRequestParameterException e
+    ) {
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(new ErrorResponse(LocalDateTime.now(), "쿼리 스트링을 확인해주세요."));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+            final HttpMediaTypeNotSupportedException e
+    ) {
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(new ErrorResponse(LocalDateTime.now(), "미디어 타입을 확인해주세요."));
+    }
+
+    @ExceptionHandler(MissingPathVariableException.class)
+    public ResponseEntity<ErrorResponse> handleMissingPathVariableException(final MissingPathVariableException e) {
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(new ErrorResponse(LocalDateTime.now(), "경로 매개변수 확인해주세요."));
     }
 }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Application 동작 중일 때 재시작 없이 설정 파일을 수정하고 적용할 수 있다.-->
+<configuration scan="true" scanPeriod="60 seconds">
+
+    <!-- 로그 파일 위치 -->
+    <property name="LOG_PATH" value="log"/>
+
+    <!-- 콘솔로 로그를 남김 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <!-- 로그 메시지 패턴 -->
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일로 로그를 남김 -->
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/info/info.log</file>
+
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 해당 패턴 네이밍으로 이전 파일이 기록됨 -->
+            <fileNamePattern>./was-logs/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- 한 파일의 최대 용량 -->
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 한 파일의 최대 저장 기한 -->
+            <maxHistory>180</maxHistory>
+            <!-- 로그 파일 최대 보관 크기 -->
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 파일로 로그를 남김 -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/error/error.log</file>
+
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 해당 패턴 네이밍으로 이전 파일이 기록됨 -->
+            <fileNamePattern>./was-logs/error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <!-- 한 파일의 최대 용량 -->
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 한 파일의 최대 저장 기한 -->
+            <maxHistory>180</maxHistory>
+            <!-- 로그 파일 최대 보관 크기 -->
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="com.digginroom.digginroom" level="info" additivity="true">
+        <appender-ref ref="INFO_FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+    </logger>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 관련 이슈번호
- resolved: #89 

## 작업 사항
- 세부 예외 처리 구현
  - 예상하지 못하는 예외 처리 구현
  - 서버 에러만 로깅하도록 리팩터링
  - 예외 핸들러 메서드 명 통일
- `Logback`을 사용한 Rolling 구현
  - `backend/log` 하위 디렉터리에 로그 파일 생성 

## 기타 사항
- 예외 핸들러 반환 시간과 서버 로그와의 미세한 시간 차이가 있습니다.
