### PR TITLE
feat: 싫어요 기능을 개발한다.

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -34,4 +34,10 @@ public class RoomController {
         roomService.unscrap(memberId, roomRequest.roomId());
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/dislike")
+    public ResponseEntity<Void> dislike(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
+        roomService.dislike(memberId, roomRequest.roomId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -43,7 +43,7 @@ public class RoomController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PostMapping("/undislike")
+    @DeleteMapping("/dislike")
     public ResponseEntity<Void> unDislike(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
         roomService.undislike(memberId, roomRequest.roomId());
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -42,4 +42,10 @@ public class RoomController {
         roomService.dislike(memberId, roomRequest.roomId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @PostMapping("/undislike")
+    public ResponseEntity<Void> unDislike(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
+        roomService.undislike(memberId, roomRequest.roomId());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -10,15 +10,17 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/room")
 public class RoomController {
 
     private final RoomService roomService;
 
-    @GetMapping("/room")
+    @GetMapping
     public ResponseEntity<RoomResponse> showRandomRoom(@Auth final Long memberId) {
         return ResponseEntity.ok().body(roomService.pickRandom(memberId));
     }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -5,11 +5,11 @@ import com.digginroom.digginroom.controller.dto.RoomResponse;
 import com.digginroom.digginroom.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,18 +19,19 @@ public class RoomController {
     private final RoomService roomService;
 
     @GetMapping("/room")
-    public RoomResponse showRandomRoom(@Auth final Long memberId) {
-        return roomService.pickRandom(memberId);
+    public ResponseEntity<RoomResponse> showRandomRoom(@Auth final Long memberId) {
+        return ResponseEntity.ok().body(roomService.pickRandom(memberId));
     }
 
     @PostMapping("/scrap")
-    @ResponseStatus(HttpStatus.CREATED)
-    public void scrap(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
+    public ResponseEntity<Void> scrap(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
         roomService.scrap(memberId, roomRequest.roomId());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/scrap")
-    public void showRandomRoom(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
+    public ResponseEntity<Void> showRandomRoom(@Auth final Long memberId, @RequestBody final RoomRequest roomRequest) {
         roomService.unscrap(memberId, roomRequest.roomId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
@@ -44,7 +44,7 @@ public class Member {
 
     public void scrap(final Room room) {
         validateUnscrapped(room);
-        validateUnDisliked(room);
+        validateUndisliked(room);
         scrapRooms.add(room);
     }
 
@@ -54,8 +54,8 @@ public class Member {
         }
     }
 
-    private void validateUnDisliked(final Room room) {
-        if (hasDislike(room)) {
+    private void validateUndisliked(final Room room) {
+        if (hasDisliked(room)) {
             throw new AlreadyDislikeException();
         }
     }
@@ -77,11 +77,11 @@ public class Member {
 
     public void dislike(final Room room) {
         validateUnscrapped(room);
-        validateUnDisliked(room);
+        validateUndisliked(room);
         dislikeRooms.add(room);
     }
 
-    private boolean hasDislike(final Room room) {
+    private boolean hasDisliked(final Room room) {
         return dislikeRooms.contains(room);
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
@@ -1,5 +1,7 @@
 package com.digginroom.digginroom.domain;
 
+import static com.digginroom.digginroom.exception.RoomException.NotDislikedException;
+
 import com.digginroom.digginroom.exception.RoomException.AlreadyDislikeException;
 import com.digginroom.digginroom.exception.RoomException.AlreadyScrappedException;
 import com.digginroom.digginroom.exception.RoomException.NotScrappedException;
@@ -83,5 +85,16 @@ public class Member {
 
     private boolean hasDisliked(final Room room) {
         return dislikeRooms.contains(room);
+    }
+
+    public void undislike(final Room room) {
+        validateDisliked(room);
+        dislikeRooms.remove(room);
+    }
+
+    private void validateDisliked(final Room room) {
+        if (!hasDisliked(room)) {
+            throw new NotDislikedException();
+        }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
@@ -48,19 +48,21 @@ public class Member {
         scrapRooms.add(room);
     }
 
-    public void unscrap(final Room room) {
-        validateScrapped(room);
-        scrapRooms.remove(room);
-    }
-
-    public boolean hasScrapped(final Room room) {
-        return scrapRooms.contains(room);
-    }
-
     private void validateUnscrapped(final Room room) {
         if (hasScrapped(room)) {
             throw new AlreadyScrappedException();
         }
+    }
+
+    private void validateUnDisliked(final Room room) {
+        if (hasDislike(room)) {
+            throw new AlreadyDislikeException();
+        }
+    }
+
+    public void unscrap(final Room room) {
+        validateScrapped(room);
+        scrapRooms.remove(room);
     }
 
     private void validateScrapped(final Room room) {
@@ -69,16 +71,14 @@ public class Member {
         }
     }
 
+    public boolean hasScrapped(final Room room) {
+        return scrapRooms.contains(room);
+    }
+
     public void dislike(final Room room) {
         validateUnscrapped(room);
         validateUnDisliked(room);
         dislikeRooms.add(room);
-    }
-
-    private void validateUnDisliked(final Room room) {
-        if (hasDislike(room)) {
-            throw new AlreadyDislikeException();
-        }
     }
 
     private boolean hasDislike(final Room room) {

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
@@ -1,5 +1,6 @@
 package com.digginroom.digginroom.domain;
 
+import com.digginroom.digginroom.exception.RoomException.AlreadyDislikeException;
 import com.digginroom.digginroom.exception.RoomException.AlreadyScrappedException;
 import com.digginroom.digginroom.exception.RoomException.NotScrappedException;
 import com.digginroom.digginroom.util.DigginRoomPasswordEncoder;
@@ -28,7 +29,9 @@ public class Member {
     @NonNull
     private String password;
     @ManyToMany
-    private final List<Room> scraps = new ArrayList<>();
+    private final List<Room> scrapRooms = new ArrayList<>();
+    @ManyToMany
+    private final List<Room> dislikeRooms = new ArrayList<>();
 
     public Member(@NonNull final String username, @NonNull final String password) {
         this.username = username;
@@ -41,16 +44,17 @@ public class Member {
 
     public void scrap(final Room room) {
         validateUnscrapped(room);
-        scraps.add(room);
+        validateUnDisliked(room);
+        scrapRooms.add(room);
     }
 
     public void unscrap(final Room room) {
         validateScrapped(room);
-        scraps.remove(room);
+        scrapRooms.remove(room);
     }
 
     public boolean hasScrapped(final Room room) {
-        return scraps.contains(room);
+        return scrapRooms.contains(room);
     }
 
     private void validateUnscrapped(final Room room) {
@@ -63,5 +67,21 @@ public class Member {
         if (!hasScrapped(room)) {
             throw new NotScrappedException();
         }
+    }
+
+    public void dislike(final Room room) {
+        validateUnscrapped(room);
+        validateUnDisliked(room);
+        dislikeRooms.add(room);
+    }
+
+    private void validateUnDisliked(final Room room) {
+        if (hasDislike(room)) {
+            throw new AlreadyDislikeException();
+        }
+    }
+
+    private boolean hasDislike(final Room room) {
+        return dislikeRooms.contains(room);
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
@@ -42,4 +42,11 @@ public abstract class RoomException extends DigginRoomException {
             super("스크랩되지 않은 룸입니다.", HttpStatus.BAD_REQUEST);
         }
     }
+
+    public static class AlreadyDislikeException extends RoomException {
+
+        public AlreadyDislikeException() {
+            super("이미 싫어요한 룸입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
@@ -49,4 +49,11 @@ public abstract class RoomException extends DigginRoomException {
             super("이미 싫어요한 룸입니다.", HttpStatus.BAD_REQUEST);
         }
     }
+
+    public static class NotDislikedException extends RoomException {
+
+        public NotDislikedException() {
+            super("싫어요하지 않은 룸입니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -75,4 +75,12 @@ public class RoomService {
 
         member.dislike(room);
     }
+
+    @Transactional
+    public void undislike(final Long memberId, final Long roomId) {
+        Room room = findRoom(roomId);
+        Member member = memberService.findMember(memberId);
+
+        member.undislike(room);
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -67,4 +67,12 @@ public class RoomService {
         return roomRepository.findById(roomId)
                 .orElseThrow(() -> new NotFoundException(roomId));
     }
+
+    @Transactional
+    public void dislike(final Long memberId, final Long roomId) {
+        Room room = findRoom(roomId);
+        Member member = memberService.findMember(memberId);
+
+        member.dislike(room);
+    }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -119,7 +119,7 @@ class RoomControllerTest extends ControllerTest {
     @Test
     void 싫어요한_룸을_스크랩_할_수_없다() {
         Response response = RestAssured.given().log().all()
-                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/login");
@@ -148,7 +148,7 @@ class RoomControllerTest extends ControllerTest {
     @Test
     void 룸을_싫어요_할_수_있다() {
         Response response = RestAssured.given().log().all()
-                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/login");
@@ -168,7 +168,7 @@ class RoomControllerTest extends ControllerTest {
     @Test
     void 싫어요한_룸을_다시_싫어요_할_수_없다() {
         Response response = RestAssured.given().log().all()
-                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/login");
@@ -197,7 +197,7 @@ class RoomControllerTest extends ControllerTest {
     @Test
     void 스크랩한_룸을_다시_싫어요_할_수_없다() {
         Response response = RestAssured.given().log().all()
-                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/login");
@@ -226,7 +226,7 @@ class RoomControllerTest extends ControllerTest {
     @Test
     void 싫어요한_룸을_취소할_수_있디() {
         Response response = RestAssured.given().log().all()
-                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/login");
@@ -255,7 +255,7 @@ class RoomControllerTest extends ControllerTest {
     @Test
     void 싫어요하지_않은_룸은_싫어요_취소할_수_없다() {
         Response response = RestAssured.given().log().all()
-                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
                 .when()
                 .post("/login");

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -82,7 +82,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/scrap")
+                .post("/room/scrap")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
     }
@@ -102,7 +102,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/scrap")
+                .post("/room/scrap")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
 
@@ -111,7 +111,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .delete("/scrap")
+                .delete("/room/scrap")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -131,7 +131,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/dislike")
+                .post("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
 
@@ -140,7 +140,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/scrap")
+                .post("/room/scrap")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
@@ -160,7 +160,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/dislike")
+                .post("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
     }
@@ -180,7 +180,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/dislike")
+                .post("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
 
@@ -189,7 +189,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/dislike")
+                .post("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
@@ -209,7 +209,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/scrap")
+                .post("/room/scrap")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
 
@@ -218,7 +218,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/dislike")
+                .post("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -115,4 +115,111 @@ class RoomControllerTest extends ControllerTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
+
+    @Test
+    void 싫어요한_룸을_스크랩_할_수_없다() {
+        Response response = RestAssured.given().log().all()
+                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/login");
+
+        String cookie = response.header("Set-Cookie");
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/dislike")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/scrap")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 룸을_싫어요_할_수_있다() {
+        Response response = RestAssured.given().log().all()
+                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/login");
+
+        String cookie = response.header("Set-Cookie");
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/dislike")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 싫어요한_룸을_다시_싫어요_할_수_없다() {
+        Response response = RestAssured.given().log().all()
+                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/login");
+
+        String cookie = response.header("Set-Cookie");
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/dislike")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/dislike")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 스크랩한_룸을_다시_싫어요_할_수_없다() {
+        Response response = RestAssured.given().log().all()
+                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/login");
+
+        String cookie = response.header("Set-Cookie");
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/scrap")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/dislike")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -222,4 +222,53 @@ class RoomControllerTest extends ControllerTest {
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
+
+    @Test
+    void 싫어요한_룸을_취소할_수_있디() {
+        Response response = RestAssured.given().log().all()
+                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/login");
+
+        String cookie = response.header("Set-Cookie");
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/room/dislike")
+                .then().log().all()
+                .statusCode(HttpStatus.CREATED.value());
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/room/undislike")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 싫어요하지_않은_룸은_싫어요_취소할_수_없다() {
+        Response response = RestAssured.given().log().all()
+                .body(new MemberLoginRequest(member.getUsername(), member.getPassword()))
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/login");
+
+        String cookie = response.header("Set-Cookie");
+
+        RestAssured.given()
+                .cookie(cookie)
+                .when()
+                .contentType(ContentType.JSON)
+                .body(new RoomRequest(room1.getId()))
+                .post("/room/undislike")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -247,7 +247,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/room/undislike")
+                .delete("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -267,7 +267,7 @@ class RoomControllerTest extends ControllerTest {
                 .when()
                 .contentType(ContentType.JSON)
                 .body(new RoomRequest(room1.getId()))
-                .post("/room/undislike")
+                .delete("/room/dislike")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -2,10 +2,12 @@ package com.digginroom.digginroom.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.digginroom.digginroom.domain.MediaSource;
 import com.digginroom.digginroom.domain.Member;
 import com.digginroom.digginroom.domain.Room;
+import com.digginroom.digginroom.exception.RoomException.AlreadyDislikeException;
 import com.digginroom.digginroom.exception.RoomException.AlreadyScrappedException;
 import com.digginroom.digginroom.exception.RoomException.NotScrappedException;
 import com.digginroom.digginroom.repository.MemberRepository;
@@ -89,5 +91,49 @@ class RoomServiceTest {
         assertThatThrownBy(() -> roomService.unscrap(member.getId(), room.getId()))
                 .isInstanceOf(NotScrappedException.class)
                 .hasMessageContaining("스크랩되지 않은 룸입니다.");
+    }
+
+    @Test
+    void 사용자는_싫어요한_룸을_스크랩할_수_없다() {
+        Member member = memberRepository.save(new Member("member", "1234"));
+        Room room = roomRepository.save(new Room(new MediaSource("lQcnNPqy2Ww")));
+
+        roomService.dislike(member.getId(), room.getId());
+
+        assertThatThrownBy(() -> roomService.scrap(member.getId(), room.getId()))
+                .isInstanceOf(AlreadyDislikeException.class)
+                .hasMessageContaining("이미 싫어요한 룸입니다.");
+    }
+
+    @Test
+    void 사용자는_룸을_싫어요_할_수_있다() {
+        Member member = memberRepository.save(new Member("member", "1234"));
+        Room room = roomRepository.save(new Room(new MediaSource("lQcnNPqy2Ww")));
+
+        assertDoesNotThrow(() -> roomService.dislike(member.getId(), room.getId()));
+    }
+
+    @Test
+    void 사용자는_이미_싫어요한_룸을_싫어요할_수_없다() {
+        Member member = memberRepository.save(new Member("member", "1234"));
+        Room room = roomRepository.save(new Room(new MediaSource("lQcnNPqy2Ww")));
+
+        roomService.dislike(member.getId(), room.getId());
+
+        assertThatThrownBy(() -> roomService.dislike(member.getId(), room.getId()))
+                .isInstanceOf(AlreadyDislikeException.class)
+                .hasMessageContaining("이미 싫어요한 룸입니다.");
+    }
+
+    @Test
+    void 사용자는_스크랩한_룸을_싫어요할_수_없다() {
+        Member member = memberRepository.save(new Member("member", "1234"));
+        Room room = roomRepository.save(new Room(new MediaSource("lQcnNPqy2Ww")));
+
+        roomService.scrap(member.getId(), room.getId());
+
+        assertThatThrownBy(() -> roomService.dislike(member.getId(), room.getId()))
+                .isInstanceOf(AlreadyScrappedException.class)
+                .hasMessageContaining("이미 스크랩된 룸입니다.");
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -51,7 +51,7 @@ class RoomServiceTest {
 
         roomService.scrap(member.getId(), room.getId());
 
-        assertThat(member.getScraps()).contains(room);
+        assertThat(member.getScrapRooms()).contains(room);
     }
 
     @Test
@@ -73,7 +73,7 @@ class RoomServiceTest {
 
         roomService.unscrap(member.getId(), room.getId());
 
-        assertThat(member.getScraps()).isEmpty();
+        assertThat(member.getScrapRooms()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈번호
- Resolved: #111 

## 작업 사항
- 싫어요 기능을 개발한다.
  - 이미 스크랩을 한 뒤에 싫어요를 할 때에는 예외가 발생하도록 변경
  - 이미 싫어요를 한 뒤에 스크랩을 할 때에는 예외가 발생하도록 구현
  - 이미 싫어요를 한 뒤에 싫어요를 할 떄에는 예외가 발생하도록 구현
- 싫어요 취소 기능을 개발한다.
  - 싫어요 하지 않은 룸에 싫어요 취소 요청시 예외가 발생하도록 구현
- endpoint 변경
  - /scrap -> /room/scrap
  - /unscrap -> /room/unscrap
  - /dislike -> /room/dislike

## 기타 사항
- 추후 스크랩, 싫어요 관련 엔티티 분리 고려