### PR TITLE
feat: 트랙 도메인 구현 및 초기 데이터 삽입

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/domain/SubGenreConverter.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/SubGenreConverter.java
@@ -1,8 +1,11 @@
 package com.digginroom.digginroom.domain;
 
+import com.digginroom.digginroom.exception.SubGenreConvertingException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.util.Arrays;
 import java.util.List;
 
 @Converter
@@ -10,13 +13,24 @@ public class SubGenreConverter implements AttributeConverter<List<String>, Strin
 
     private static final String DELIMITER = ",";
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public String convertToDatabaseColumn(final List<String> attribute) {
-        return String.join(DELIMITER, attribute);
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new SubGenreConvertingException();
+        }
     }
 
     @Override
     public List<String> convertToEntityAttribute(final String dbData) {
-        return Arrays.asList(dbData.split(DELIMITER));
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new SubGenreConvertingException();
+        }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/SubGenreConverter.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/SubGenreConverter.java
@@ -1,0 +1,22 @@
+package com.digginroom.digginroom.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class SubGenreConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(final List<String> attribute) {
+        return String.join(DELIMITER, attribute);
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(final String dbData) {
+        return Arrays.asList(dbData.split(DELIMITER));
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
@@ -29,7 +29,7 @@ public class Track {
     private List<String> subGenres;
 
     @Builder
-    public Track(final String title, final String artist, final String superGenre, final List<String> subGenres) {
+    private Track(final String title, final String artist, final String superGenre, final List<String> subGenres) {
         this.title = title;
         this.artist = artist;
         this.superGenre = superGenre;

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
@@ -1,0 +1,38 @@
+package com.digginroom.digginroom.domain;
+
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"title", "artist"}))
+public class Track {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String artist;
+    private String superGenre;
+    @Convert(converter = SubGenreConverter.class)
+    private List<String> subGenres;
+
+    @Builder
+    public Track(final String title, final String artist, final String superGenre, final List<String> subGenres) {
+        this.title = title;
+        this.artist = artist;
+        this.superGenre = superGenre;
+        this.subGenres = subGenres;
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/exception/SubGenreConvertingException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/SubGenreConvertingException.java
@@ -1,0 +1,10 @@
+package com.digginroom.digginroom.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class SubGenreConvertingException extends DigginRoomException {
+
+    public SubGenreConvertingException() {
+        super("서브장르 변환에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -71,3 +71,11 @@ INSERT INTO ROOM(media_source_id) VALUES(33);
 INSERT INTO ROOM(media_source_id) VALUES(34);
 INSERT INTO ROOM(media_source_id) VALUES(35);
 INSERT INTO ROOM(media_source_id) VALUES(36);
+
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Speak to me', 'Zaumne', 'Sounds and Effects', 'Outsider House,ASMR,Ambient House,Ambient Dub,Spoken Word');
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Friends', 'Zaumne', 'Sounds and Effects', 'Outsider House,ASMR,Ambient House,Ambient Dub,Spoken Word');
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Hand in Hand', 'Zaumne', 'Sounds and Effects', 'Outsider House,ASMR,Ambient House,Ambient Dub,Spoken Word');
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Valis', 'Félicia Atkinson', 'Sounds and Effects', 'Electroacoustic,Ambient,ASMR,Spoken,Drone');
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Monstera deliciosa', 'Félicia Atkinson', 'Sounds and Effects', 'Electroacoustic,Ambient,ASMR,Spoken,Drone');
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Curious in Epidavros', 'Félicia Atkinson', 'Sounds and Effects', 'Electroacoustic,Ambient,ASMR,Spoken,Drone');
+INSERT INTO track(title, artist, super_genre, sub_genres) VALUES ('Born Under Punches (The Heat Goes On)', 'Talking Heads', 'Punk', 'New Wave,Post-Punk,Funk,Afrobeat,Experimental Rock,Dance-Punk');

--- a/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
@@ -1,0 +1,43 @@
+package com.digginroom.digginroom.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+class TrackTest {
+
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void 서브장르가_컨버터를_통해서_문자열로_변환된다() {
+        Track track = Track.builder()
+                .artist("코건")
+                .title("Lost Child")
+                .superGenre("Rock")
+                .subGenres(List.of("Alternative Rock", "Noise Rock"))
+                .build();
+
+        em.persist(track);
+        em.flush();
+
+        String subGenre = jdbcTemplate.queryForObject(
+                "select sub_genres from track where id=?",
+                String.class,
+                track.getId()
+        );
+        assertThat(subGenre).isEqualTo("Alternative Rock,Noise Rock");
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
@@ -38,6 +38,6 @@ class TrackTest {
                 String.class,
                 track.getId()
         );
-        assertThat(subGenre).isEqualTo("Alternative Rock,Noise Rock");
+        assertThat(subGenre).isEqualTo("[\"Alternative Rock\",\"Noise Rock\"]");
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
@@ -11,9 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+@DataJpaTest
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DataJpaTest
 class TrackTest {
 
     @Autowired


### PR DESCRIPTION
## 관련 이슈번호
- #135 

## 작업 사항
- 트랙 도메인을 구현한다
- 초기 데이터를 삽입한다. (7개, 후속 작업용 샘플)
- `AttributeConverter`를 사용한 서브 장르 영속화 방식 지정
  - 추천은 슈퍼장르로 발생하므로 서브 장르는 테이블로 분리할 만큼 중요한 정보가 아님
  - 수정, 삭제, 개별조회 등의 행위가 현재 발생하지 않음
  - JSON 형식으로 저장
    - 음악 제목에 `,` 가 존재할 수 있다.
    - `,`, `|` 등 특정 문자를 사용하는 것보다는, '표준 데이터 표현 방식' 인 JSON을 사용하면 특수문자로부터 자유로워질 수 있다.

## 기타 사항
### 설계
|객체 설계|스키마|
|---|---|
|![Image](https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/c1c6c0e6-cf9c-46f2-894c-abe61f5c7cac)|![Image](https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/9ea3d55a-e4a2-424e-80b0-652eafae4216)|

### 비즈니스 결정사항
- 같은 아티스트의 같은 제목은 같은 곡으로 취급한다.
- 같은 아티스트의 어떤 두 곡이 한글자라도 다르다면 다른 곡으로 취급한다.