### PR TITLE
fix: 배포 스크립트 오류를 해결한다

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -18,6 +18,7 @@ jobs:
           ./gradlew bootjar
 
       - name: kill previous process
+        shell: bash {0}
         run: |
           JAR_NAME="DigginRoom-0.0.1-SNAPSHOT.jar"
           PROCESS_ID=$(pgrep -f "$JAR_NAME")

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -18,6 +18,7 @@ jobs:
           ./gradlew bootjar
 
       - name: kill previous process
+        shell: bash {0}
         run: |
           JAR_NAME="DigginRoom-0.0.1-SNAPSHOT.jar"
           PROCESS_ID=$(pgrep -f "$JAR_NAME")


### PR DESCRIPTION
## 관련 이슈번호
- #183 

## 작업 사항
### 원인
- 배포 스크립트 중 'pgrep -f' 에서 exit code 1(오류) 발생 
- `DigginRoom-xxx.jar`에 해당하는 프로세스를 찾지 못했기 때문

<img width="650" alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/baf7d447-f5cb-4bb3-affe-c00db45920d1">

### 해결
해당 프로세스를 찾지 못해도 스크립트가 정상적으로 0을 반환하도록 설정
<img width="453" alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/ef2df906-5c56-46df-b32d-430e63382bdb">
[참고한 자료](https://stackoverflow.com/questions/73066461/github-actions-why-an-intermediate-command-failure-in-shell-script-would-cause)

## 기타 사항
<br/>
