### PR TITLE
feat: 싫어요 정책 수정사항을 반영

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/domain/DislikeRooms.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/DislikeRooms.java
@@ -1,6 +1,5 @@
 package com.digginroom.digginroom.domain;
 
-import com.digginroom.digginroom.exception.RoomException.AlreadyDislikeException;
 import com.digginroom.digginroom.exception.RoomException.NotDislikedException;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.ManyToMany;
@@ -19,14 +18,7 @@ public class DislikeRooms {
     private final List<Room> dislikeRooms = new ArrayList<>();
 
     public void dislike(final Room room) {
-        validateUndisliked(room);
         dislikeRooms.add(room);
-    }
-
-    private void validateUndisliked(final Room room) {
-        if (hasDisliked(room)) {
-            throw new AlreadyDislikeException();
-        }
     }
 
     public boolean hasDisliked(final Room room) {

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
@@ -1,13 +1,12 @@
 package com.digginroom.digginroom.domain;
 
-import com.digginroom.digginroom.exception.RoomException.AlreadyDislikeException;
-import com.digginroom.digginroom.exception.RoomException.AlreadyScrappedException;
 import com.digginroom.digginroom.util.DigginRoomPasswordEncoder;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -70,7 +69,15 @@ public class Member {
         return scrapRooms.hasScrapped(pickedRoom);
     }
 
-    public MemberGenres getMemberGenres() {
-        return memberGenres;
+    public List<MemberGenre> getMemberGenres() {
+        return memberGenres.getMemberGenres();
+    }
+
+    public List<Room> getScrapRooms() {
+        return scrapRooms.getScrapRooms();
+    }
+
+    public List<Room> getDislikeRooms() {
+        return dislikeRooms.getDislikeRooms();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Member.java
@@ -42,41 +42,28 @@ public class Member {
     }
 
     public void scrap(final Room room) {
-        validateNotDisliked(room);
         scrapRooms.scrap(room);
-        Genre superGenre = room.getTrack().getSuperGenre();
-        memberGenres.adjustWeightBy(superGenre, Weight.SCRAP);
+        adjustMemberGenreWeight(room, Weight.SCRAP);
     }
 
-    private void validateNotDisliked(final Room room) {
-        if (dislikeRooms.hasDisliked(room)) {
-            throw new AlreadyDislikeException();
-        }
+    private void adjustMemberGenreWeight(final Room room, final Weight scrap) {
+        Genre superGenre = room.getTrack().getSuperGenre();
+        memberGenres.adjustWeightBy(superGenre, scrap);
     }
 
     public void unscrap(final Room room) {
         scrapRooms.unscrap(room);
-        Genre superGenre = room.getTrack().getSuperGenre();
-        memberGenres.adjustWeightBy(superGenre, Weight.UNSCRAP);
+        adjustMemberGenreWeight(room, Weight.UNSCRAP);
     }
 
     public void dislike(final Room room) {
-        validateNotScrapped(room);
         dislikeRooms.dislike(room);
-        Genre superGenre = room.getTrack().getSuperGenre();
-        memberGenres.adjustWeightBy(superGenre, Weight.DISLIKE);
-    }
-
-    private void validateNotScrapped(final Room room) {
-        if (scrapRooms.hasScrapped(room)) {
-            throw new AlreadyScrappedException();
-        }
+        adjustMemberGenreWeight(room, Weight.DISLIKE);
     }
 
     public void undislike(final Room room) {
         dislikeRooms.undislike(room);
-        Genre superGenre = room.getTrack().getSuperGenre();
-        memberGenres.adjustWeightBy(superGenre, Weight.UNDISLIKE);
+        adjustMemberGenreWeight(room, Weight.UNDISLIKE);
     }
 
     public boolean hasScrapped(final Room pickedRoom) {

--- a/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/RoomException.java
@@ -15,13 +15,6 @@ public abstract class RoomException extends DigginRoomException {
         }
     }
 
-    public static class EmptyException extends RoomException {
-
-        public EmptyException() {
-            super("더 이상 룸이 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
     public static class NoMediaSourceException extends RoomException {
 
         public NoMediaSourceException() {
@@ -40,13 +33,6 @@ public abstract class RoomException extends DigginRoomException {
 
         public NotScrappedException() {
             super("스크랩되지 않은 룸입니다.", HttpStatus.BAD_REQUEST);
-        }
-    }
-
-    public static class AlreadyDislikeException extends RoomException {
-
-        public AlreadyDislikeException() {
-            super("이미 싫어요한 룸입니다.", HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -5,9 +5,7 @@ import com.digginroom.digginroom.controller.dto.RoomsResponse;
 import com.digginroom.digginroom.controller.dto.TrackResponse;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.Member;
-import com.digginroom.digginroom.domain.MemberGenres;
 import com.digginroom.digginroom.domain.Room;
-import com.digginroom.digginroom.domain.ScrapRooms;
 import com.digginroom.digginroom.domain.Track;
 import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import com.digginroom.digginroom.repository.RoomRepository;
@@ -30,9 +28,9 @@ public class RoomService {
     @Transactional(readOnly = true)
     public RoomResponse recommend(final Long memberId) {
         Member member = memberService.findMember(memberId);
-        MemberGenres memberGenres = member.getMemberGenres();
+
         try {
-            Genre recommendedGenre = new GenreRecommender().recommend(memberGenres.getMemberGenres());
+            Genre recommendedGenre = new GenreRecommender().recommend(member.getMemberGenres());
             Track recommendedTrack = recommendTrack(recommendedGenre);
             Room recommendedRoom = recommendedTrack.recommendRoom();
 
@@ -57,8 +55,7 @@ public class RoomService {
     @Transactional(readOnly = true)
     public RoomsResponse findScrappedRooms(final Long memberId) {
         Member member = memberService.findMember(memberId);
-        ScrapRooms scrapRooms = member.getScrapRooms();
-        return new RoomsResponse(scrapRooms.getScrapRooms().stream()
+        return new RoomsResponse(member.getScrapRooms().stream()
                 .map(room -> new RoomResponse(
                         room.getId(),
                         room.getMediaSource().getIdentifier(),

--- a/backend/src/test/java/com/digginroom/digginroom/controller/MemberJoinControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/MemberJoinControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.test.annotation.DirtiesContext;
 @SuppressWarnings("NonAsciiCharacters")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class MemberJoinControllerTest extends ControllerTest {
-    
+
     @Test
     void 회원가입을_할_수_있다() {
         RestAssured.given().log().all()

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -127,7 +127,7 @@ class RoomControllerTest extends ControllerTest {
     }
 
     @Test
-    void 싫어요한_룸을_스크랩_할_수_없다() {
+    void 싫어요한_룸을_스크랩_할_수_있다() {
         Response response = RestAssured.given().log().all()
                 .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
@@ -152,7 +152,7 @@ class RoomControllerTest extends ControllerTest {
                 .body(new RoomRequest(room1.getId()))
                 .post("/room/scrap")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
@@ -176,7 +176,7 @@ class RoomControllerTest extends ControllerTest {
     }
 
     @Test
-    void 싫어요한_룸을_다시_싫어요_할_수_없다() {
+    void 싫어요한_룸도_여러번_싫어요할_수_있다() {
         Response response = RestAssured.given().log().all()
                 .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
@@ -201,11 +201,11 @@ class RoomControllerTest extends ControllerTest {
                 .body(new RoomRequest(room1.getId()))
                 .post("/room/dislike")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     @Test
-    void 스크랩한_룸을_다시_싫어요_할_수_없다() {
+    void 스크랩한_룸을_싫어요_할_수_있다() {
         Response response = RestAssured.given().log().all()
                 .body(MEMBER_LOGIN_REQUEST)
                 .contentType(ContentType.JSON)
@@ -230,7 +230,7 @@ class RoomControllerTest extends ControllerTest {
                 .body(new RoomRequest(room1.getId()))
                 .post("/room/dislike")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     @Test

--- a/backend/src/test/java/com/digginroom/digginroom/domain/MemberTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/MemberTest.java
@@ -1,0 +1,84 @@
+package com.digginroom.digginroom.domain;
+
+import static com.digginroom.digginroom.controller.TestFixture.나무;
+import static com.digginroom.digginroom.controller.TestFixture.파워;
+import static com.digginroom.digginroom.domain.Weight.DEFAULT;
+import static com.digginroom.digginroom.domain.Weight.DISLIKE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.digginroom.digginroom.exception.RoomException.NotDislikedException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MemberTest {
+
+    @Test
+    void 멤버는_싫어요한_룸도_여러번_싫어요할_수_있다() {
+        Member 파워 = 파워();
+        Room 나무 = 나무();
+
+        파워.dislike(나무);
+        파워.dislike(나무);
+        int weight = getWeight(파워, Genre.ROCK);
+
+        assertAll(() -> assertThat(weight).isEqualTo(DEFAULT.getWeight() + DISLIKE.getWeight() * 2),
+                () -> assertThat(파워.getDislikeRooms()).usingRecursiveComparison().isEqualTo(List.of(나무, 나무)));
+    }
+
+    @Test
+    void 멤버는_싫어요_취소한_만큼_가중치를_복구한다() {
+        Member 파워 = 파워();
+        Room 나무 = 나무();
+
+        파워.dislike(나무);
+        파워.dislike(나무);
+        파워.undislike(나무);
+        int weight = getWeight(파워, Genre.ROCK);
+
+        assertAll(() -> assertThat(weight).isEqualTo(DEFAULT.getWeight() + DISLIKE.getWeight()),
+                () -> assertThat(파워.getDislikeRooms()).usingRecursiveComparison().isEqualTo(List.of(나무)));
+    }
+
+    @Test
+    void 멤버는_싫어요하지_않은_룸을_싫어요_취소할_수_없다() {
+        Member 파워 = 파워();
+
+        assertThatThrownBy(() -> 파워.undislike(나무())).isInstanceOf(NotDislikedException.class)
+                .hasMessage("싫어요하지 않은 룸입니다.");
+    }
+
+    @Test
+    void 멤버는_싫어요한_룸도_스크랩_할_수_있다() {
+        Member 파워 = 파워();
+        Room 나무 = 나무();
+
+        파워.dislike(나무);
+
+        assertDoesNotThrow(() -> 파워.scrap(나무));
+    }
+
+    @Test
+    void 멤버는_스크랩한_룸도_싫어요_할_수_있다() {
+        Member 파워 = 파워();
+        Room 나무 = 나무();
+
+        파워.scrap(나무);
+
+        assertDoesNotThrow(() -> 파워.dislike(나무));
+    }
+
+    private int getWeight(final Member member, final Genre targetGenre) {
+        return member.getMemberGenres()
+                .stream()
+                .filter(it -> it.isSameGenre(targetGenre))
+                .findFirst().get()
+                .getWeight();
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/repository/MemberRepositoryTest.java
@@ -28,7 +28,7 @@ class MemberRepositoryTest {
 
         Member saved파워 = memberRepository.save(파워);
 
-        assertThat(saved파워.getMemberGenres().getMemberGenres()).hasSize(Genre.values().length);
+        assertThat(saved파워.getMemberGenres()).hasSize(Genre.values().length);
     }
 
     @Test
@@ -39,6 +39,6 @@ class MemberRepositoryTest {
 
         Member found = memberRepository.findById(saved파워.getId()).get();
 
-        assertThat(found.getMemberGenres().getMemberGenres()).hasSize(Genre.values().length);
+        assertThat(found.getMemberGenres()).hasSize(Genre.values().length);
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -138,15 +138,13 @@ class RoomServiceTest {
     }
 
     @Test
-    void 사용자는_싫어요한_룸을_스크랩할_수_없다() {
+    void 사용자는_싫어요한_룸을_스크랩할_수_있다() {
         Member member = memberRepository.save(파워());
         Room room = roomRepository.save(차이());
 
         roomService.dislike(member.getId(), room.getId());
 
-        assertThatThrownBy(() -> roomService.scrap(member.getId(), room.getId()))
-                .isInstanceOf(AlreadyDislikeException.class)
-                .hasMessageContaining("이미 싫어요한 룸입니다.");
+        assertDoesNotThrow(() -> roomService.scrap(member.getId(), room.getId()));
     }
 
     @Test
@@ -160,27 +158,23 @@ class RoomServiceTest {
     }
 
     @Test
-    void 사용자는_이미_싫어요한_룸을_싫어요할_수_없다() {
+    void 사용자는_이미_싫어요한_룸을_싫어요할_수_있다() {
         Member member = memberRepository.save(파워());
         Room room = roomRepository.save(차이());
 
         roomService.dislike(member.getId(), room.getId());
 
-        assertThatThrownBy(() -> roomService.dislike(member.getId(), room.getId()))
-                .isInstanceOf(AlreadyDislikeException.class)
-                .hasMessageContaining("이미 싫어요한 룸입니다.");
+        assertDoesNotThrow(() -> roomService.dislike(member.getId(), room.getId()));
     }
 
     @Test
-    void 사용자는_스크랩한_룸을_싫어요할_수_없다() {
+    void 사용자는_스크랩한_룸을_싫어요할_수_있다() {
         Member member = memberRepository.save(파워());
         Room room = roomRepository.save(차이());
 
         roomService.scrap(member.getId(), room.getId());
 
-        assertThatThrownBy(() -> roomService.dislike(member.getId(), room.getId()))
-                .isInstanceOf(AlreadyScrappedException.class)
-                .hasMessageContaining("이미 스크랩된 룸입니다.");
+        assertDoesNotThrow(() -> roomService.dislike(member.getId(), room.getId()));
     }
 
     @Test

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -5,6 +5,7 @@ import static com.digginroom.digginroom.controller.TestFixture.차이;
 import static com.digginroom.digginroom.controller.TestFixture.파워;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.digginroom.digginroom.controller.dto.RoomResponse;
 import com.digginroom.digginroom.controller.dto.RoomsResponse;
@@ -12,7 +13,6 @@ import com.digginroom.digginroom.controller.dto.TrackResponse;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.Member;
 import com.digginroom.digginroom.domain.Room;
-import com.digginroom.digginroom.exception.RoomException.AlreadyDislikeException;
 import com.digginroom.digginroom.exception.RoomException.AlreadyScrappedException;
 import com.digginroom.digginroom.exception.RoomException.NotDislikedException;
 import com.digginroom.digginroom.exception.RoomException.NotScrappedException;
@@ -97,7 +97,7 @@ class RoomServiceTest {
 
         roomService.scrap(member.getId(), room.getId());
 
-        assertThat(member.getScrapRooms().getScrapRooms()).contains(room);
+        assertThat(member.getScrapRooms()).contains(room);
     }
 
     @Test
@@ -119,7 +119,7 @@ class RoomServiceTest {
 
         roomService.unscrap(member.getId(), room.getId());
 
-        assertThat(member.getScrapRooms().getScrapRooms()).isEmpty();
+        assertThat(member.getScrapRooms()).isEmpty();
     }
 
     @Test
@@ -154,7 +154,7 @@ class RoomServiceTest {
 
         roomService.dislike(member.getId(), room.getId());
 
-        assertThat(member.getDislikeRooms().getDislikeRooms()).isNotEmpty();
+        assertThat(member.getDislikeRooms()).isNotEmpty();
     }
 
     @Test
@@ -185,7 +185,7 @@ class RoomServiceTest {
 
         roomService.undislike(member.getId(), room.getId());
 
-        assertThat(member.getDislikeRooms().getDislikeRooms()).isEmpty();
+        assertThat(member.getDislikeRooms()).isEmpty();
     }
 
     @Test
@@ -212,7 +212,7 @@ class RoomServiceTest {
     }
 
     private int getWeight(final Member member, final Genre targetGenre) {
-        return member.getMemberGenres().getMemberGenres().stream()
+        return member.getMemberGenres().stream()
                 .filter(it -> it.isSameGenre(targetGenre))
                 .findFirst()
                 .get().getWeight();


### PR DESCRIPTION
## 관련 이슈번호
- #196 

## 작업 사항
### ✅ 스크랩

- 스크랩을 할 때 그 룸이 이미 스크랩 되어 있으면 예외
- 스크랩 취소를 할 때 그 룸이 스크랩 되어 있지 않으면 예외
- 스크랩을 할 때 그 룸이 싫어요 되어있어도 가능하다.
- 스크랩을 할 때 가중치가 올라간다.
- 스크랩을 취소할 때 가중치가 복구된다.

### ✅ 싫어요

- 싫어요는 여러번 할 수 있다.
    - 하나의 룸에 대한 각 싫어요 마다 가중치를 매번 줄여준다.
- 싫어요 취소는 여러번 할 수 있다.
    - 하나의 룸에 대한 싫어요 취소마다 가중치를 매번 복구한다.
- 싫어요 취소를 할 때 그 룸이 싫어요 되어 있지 않으면 예외
- 싫어요 할 때 그 룸이 이미 스크랩되어있어도 가능하다.

## 기타 사항
`Member` 에서 스크랩 목록 및 싫어요 목록을 가져올때 List형식으로 반환하도록 수정
