### PR TITLE
refactor: 소셜 로그인 인증 예외를 리팩토링한다

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/exception/OAuthResolverException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/OAuthResolverException.java
@@ -2,9 +2,23 @@ package com.digginroom.digginroom.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class OAuthResolverException extends DigginRoomException {
+public abstract class OAuthResolverException extends DigginRoomException {
 
-    public OAuthResolverException() {
-        super("OAuth username을 읽지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    public OAuthResolverException(final String message, final HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+
+    public static class IdTokenNotReadableException extends OAuthResolverException {
+
+        public IdTokenNotReadableException() {
+            super("OAuth username을 읽지 못했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public static class InvalidIdTokenException extends OAuthResolverException {
+
+        public InvalidIdTokenException() {
+            super("잘못된 토큰입니다", HttpStatus.BAD_REQUEST);
+        }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/GoogleUsernameResolver.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/GoogleUsernameResolver.java
@@ -1,6 +1,7 @@
 package com.digginroom.digginroom.service;
 
-import com.digginroom.digginroom.exception.OAuthResolverException;
+import com.digginroom.digginroom.exception.OAuthResolverException.IdTokenNotReadableException;
+import com.digginroom.digginroom.exception.OAuthResolverException.InvalidIdTokenException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
@@ -23,9 +24,11 @@ public class GoogleUsernameResolver implements OAuthUsernameResolver {
             if (tokenVerifier.verify(googleIdToken)) {
                 return googleIdToken.getPayload().getSubject();
             }
-            throw new OAuthResolverException();
-        } catch (IOException | GeneralSecurityException | IllegalArgumentException e) {
-            throw new OAuthResolverException();
+            throw new InvalidIdTokenException();
+        } catch (IllegalArgumentException e) {
+            throw new InvalidIdTokenException();
+        } catch (IOException | GeneralSecurityException e) {
+            throw new IdTokenNotReadableException();
         }
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/GoogleUsernameResolverTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/GoogleUsernameResolverTest.java
@@ -2,7 +2,7 @@ package com.digginroom.digginroom.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.digginroom.digginroom.exception.OAuthResolverException;
+import com.digginroom.digginroom.exception.OAuthResolverException.InvalidIdTokenException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -20,18 +20,18 @@ class GoogleUsernameResolverTest {
     @Test
     void 기간이_지난_ID_TOKEN을_사용하면_예외를_던진다() {
         assertThatThrownBy(() -> resolver.resolve(EXPIRED_ID_TOKEN))
-                .isInstanceOf(OAuthResolverException.class);
+                .isInstanceOf(InvalidIdTokenException.class);
     }
 
     @Test
     void 잘못된_길이의_ID_TOKEN은_예외를_던진다() {
         assertThatThrownBy(() -> resolver.resolve(SHORT_ID_TOKEN))
-                .isInstanceOf(OAuthResolverException.class);
+                .isInstanceOf(InvalidIdTokenException.class);
     }
 
     @Test
     void 잘못된_ID_TOKEN은_예외를_던진다() {
         assertThatThrownBy(() -> resolver.resolve(INVALID_ID_TOKEN))
-                .isInstanceOf(OAuthResolverException.class);
+                .isInstanceOf(InvalidIdTokenException.class);
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
- #214 

## 작업 사항
- 인증 예외를 두 가지로 분리한다.
  a. Id Token 자체가 잘못된 경우 (클라이언트 측 오류)
  b. 서버가 모종의 이유로 Id Token을 해석할 수 없는 경우 (서버 측 오류)

b의 경우는 인증 과정 상 크리티컬한 문제이므로 별도로 분리하였음.

## 기타 사항
<br/>
