### PR TITLE
feat: 트랙에 음악 설명 필드 추가

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/TrackResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/TrackResponse.java
@@ -2,13 +2,14 @@ package com.digginroom.digginroom.controller.dto;
 
 import com.digginroom.digginroom.domain.Track;
 
-public record TrackResponse(String title, String artist, String superGenre) {
+public record TrackResponse(String title, String artist, String superGenre, String description) {
 
     public static TrackResponse of(Track track) {
         return new TrackResponse(
                 track.getTitle(),
                 track.getArtist(),
-                track.getSuperGenre().getName()
+                track.getSuperGenre().getName(),
+                track.getDescription()
         );
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
@@ -1,5 +1,6 @@
 package com.digginroom.digginroom.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,7 +8,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -34,7 +34,7 @@ public class Track {
     private Genre superGenre;
     @Convert(converter = SubGenreConverter.class)
     private List<String> subGenres;
-    @Lob
+    @Column(length = 500)
     private String description;
     @OneToMany(mappedBy = "track")
     private final List<Room> rooms = new ArrayList<>();

--- a/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/Track.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -33,15 +34,24 @@ public class Track {
     private Genre superGenre;
     @Convert(converter = SubGenreConverter.class)
     private List<String> subGenres;
+    @Lob
+    private String description;
     @OneToMany(mappedBy = "track")
     private final List<Room> rooms = new ArrayList<>();
 
     @Builder
-    private Track(final String title, final String artist, final Genre superGenre, final List<String> subGenres) {
+    public Track(
+            final String title,
+            final String artist,
+            final Genre superGenre,
+            final List<String> subGenres,
+            final String description
+    ) {
         this.title = title;
         this.artist = artist;
         this.superGenre = superGenre;
         this.subGenres = subGenres;
+        this.description = description;
     }
 
     public Room recommendRoom() {

--- a/backend/src/main/resources/db/migration/V3__track_description_added.sql
+++ b/backend/src/main/resources/db/migration/V3__track_description_added.sql
@@ -1,2 +1,1 @@
-ALTER TABLE track
-    ADD COLUMN description clob NOT NULL DEFAULT ' ';
+ALTER TABLE track ADD COLUMN description varchar(500) NOT NULL DEFAULT ' ';

--- a/backend/src/main/resources/db/migration/V3__track_description_added.sql
+++ b/backend/src/main/resources/db/migration/V3__track_description_added.sql
@@ -1,0 +1,2 @@
+ALTER TABLE track
+    ADD COLUMN description clob NOT NULL DEFAULT ' ';

--- a/backend/src/test/java/com/digginroom/digginroom/controller/TestFixture.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/TestFixture.java
@@ -28,6 +28,7 @@ public class TestFixture {
                 .title("나무")
                 .superGenre(Genre.ROCK)
                 .subGenres(List.of("Alternative Rock", "Noise Rock"))
+                .description("코건은 코건")
                 .build();
         return new Room(new MediaSource("lQcnNPqy2Ww"), track);
     }
@@ -38,6 +39,7 @@ public class TestFixture {
                 .title("차이코프스키 6번 교향곡")
                 .superGenre(Genre.CLASSICAL_MUSIC)
                 .subGenres(List.of("Alternative Rock", "Noise Rock"))
+                .description("콩하나는 콩둘")
                 .build();
         return new Room(new MediaSource("2VkWaOOF4Rc"), track);
     }

--- a/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/domain/TrackTest.java
@@ -28,6 +28,7 @@ class TrackTest {
                 .title("Lost Child")
                 .superGenre(Genre.ROCK)
                 .subGenres(List.of("Alternative Rock", "Noise Rock"))
+                .description("코건은 코건")
                 .build();
 
         em.persist(track);


### PR DESCRIPTION
## 관련 이슈번호
- #220 

## 작업 사항
- Track 도메인에 Description 필드 추가
- Track Response에 Description 필드 추가
- 테스트 코드에 Description 추가
- Flyway V3 파일 생성

## 기타 사항
기존 Track 데이터(_data.sql_)에 Description이 없을 경우를 대비해서 Default 를 `" "` 으로 주었습니다.
