### PR TITLE
feat: 로그인 응답에 취향정보 수집되었는지 여부 추가

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/controller/MemberLoginController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/MemberLoginController.java
@@ -24,7 +24,7 @@ public class MemberLoginController {
     private final MemberService memberService;
 
     @PostMapping
-    public ResponseEntity<Void> login(
+    public ResponseEntity<MemberLoginResponse> login(
             @RequestBody @Valid final MemberLoginRequest memberLoginRequest,
             final HttpSession httpSession
     ) {
@@ -32,11 +32,12 @@ public class MemberLoginController {
 
         httpSession.setAttribute("memberId", member.memberId());
         httpSession.setMaxInactiveInterval(PERSISTENT_TIME);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(member);
     }
 
     @PostMapping("/google")
-    public ResponseEntity<Void> login(
+    public ResponseEntity<MemberLoginResponse> login(
             @RequestBody @Valid final GoogleOAuthRequest googleOAuthRequest,
             final HttpSession httpSession
     ) {
@@ -44,7 +45,7 @@ public class MemberLoginController {
 
         httpSession.setAttribute("memberId", member.memberId());
         httpSession.setMaxInactiveInterval(PERSISTENT_TIME);
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(member);
     }
-
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/MemberLoginResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/MemberLoginResponse.java
@@ -1,4 +1,13 @@
 package com.digginroom.digginroom.controller.dto;
 
-public record MemberLoginResponse(Long memberId) {
+import com.digginroom.digginroom.domain.Member;
+
+public record MemberLoginResponse(Long memberId, boolean hasFavorite) {
+
+    public static MemberLoginResponse of(Member member) {
+        return new MemberLoginResponse(
+                member.getId(),
+                member.hasFavorite()
+        );
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
@@ -70,7 +70,7 @@ public class MemberService {
         if (member.getPassword().doesNotMatch(request.password())) {
             throw new NotFoundException();
         }
-        return new MemberLoginResponse(member.getId());
+        return MemberLoginResponse.of(member);
     }
 
     public MemberLoginResponse loginMember(final GoogleOAuthRequest request) {
@@ -81,6 +81,6 @@ public class MemberService {
                         new Member(googleUsername, Provider.GOOGLE))
                 );
 
-        return new MemberLoginResponse(member.getId());
+        return MemberLoginResponse.of(member);
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
@@ -92,7 +92,7 @@ class MemberServiceTest {
         when(memberRepository.findMemberByUsername("power")).thenReturn(Optional.of(power));
 
         assertThat(memberService.loginMember(new MemberLoginRequest(power.getUsername(), "power123!")))
-                .isEqualTo(new MemberLoginResponse(power.getId()));
+                .isEqualTo(MemberLoginResponse.of(power));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈번호
- #213
- **PR 대상: #224**
  - 기존 브랜치 `feature/213` 에 머지할 내용입니다.
## 작업 사항
- 로그인 API에 취향정보 수집되었는지 여부 추가

POST /login, /login/google
RESPONSE
```json
{
  "memberId": 1
  "hasFavorite": false
}
```

## 기타 사항
<br/>
