### PR TITLE
feat: 문서화 라이브러리 도입

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-mysql'
 
     implementation 'com.google.api-client:google-api-client-servlet:2.0.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/com/digginroom/digginroom/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/digginroom/digginroom/config/OpenApiConfig.java
@@ -1,0 +1,65 @@
+package com.digginroom.digginroom.config;
+
+import com.digginroom.digginroom.controller.Auth;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import java.util.Arrays;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String SESSION_SECURITY_KEY = "session";
+    private static final SecurityRequirement SESSION_SECURITY_ITEM = new SecurityRequirement().addList(
+            SESSION_SECURITY_KEY
+    );
+
+    static {
+        SpringDocUtils.getConfig()
+                .addAnnotationsToIgnore(Auth.class);
+    }
+
+    @Bean
+    public OpenAPI openApiSpecification() {
+        return new OpenAPI()
+                .info(new Info()
+                        .version("v0.0.1")
+                        .title("디깅룸 API")
+                        .description("접근한 서버의 최신 API 스펙입니다")
+                )
+                .components(new Components()
+                        .addSecuritySchemes(
+                                SESSION_SECURITY_KEY,
+                                sessionSecurityScheme()
+                        )
+                );
+    }
+
+    private SecurityScheme sessionSecurityScheme() {
+        return new SecurityScheme()
+                .type(Type.APIKEY)
+                .in(In.COOKIE)
+                .name("JSESSIONID");
+    }
+
+    @Bean
+    public OperationCustomizer authOperationMarker() {
+        return (operation, handlerMethod) -> {
+            Arrays.stream(handlerMethod.getMethodParameters())
+                    .filter(methodParameter -> methodParameter.hasParameterAnnotation(Auth.class))
+                    .findAny()
+                    .ifPresent(
+                            it -> operation.addSecurityItem(SESSION_SECURITY_ITEM)
+                    );
+            return operation;
+        };
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,3 +12,10 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 0
+springdoc:
+  api-docs:
+    path: /docs
+  swagger-ui:
+    path: /docs
+  cache:
+    disabled: true


### PR DESCRIPTION
## 관련 이슈번호
- #229 

## 작업 사항
- 문서화 
  - springdocs 라이브러리 사용
    - 최신 상태의 API를 문서화 하겠다는 목적에 잘 부합함
    - Rest Docs에 비해 문서화 비용(인력, 시간)이 아주 적게 듦
    - 컨트롤러에서 API의 세부사항을 함께 관리할 수 있음(행위 설명, 기능 설명 등)
    - 요청/응답 DTO와 세부사항을 함께 관리할 수 있음(필드 설명)
    - 프로덕션 코드에 문서화 관련 어노테이션이 일부 추가될 수 있음

## 미리보기
| 문서 | 인증 |
|--------|--------|
| <img alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/242990b1-5fc7-4e35-9cda-be073d8c5720"> | <img alt="스크린샷 2023-08-13 20 17 32" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/a2c5f0e1-b672-4dd0-8e12-1e8ea1e07bb1"> | 

## 기타 사항
<img width="499" alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/add1ffc6-4d7e-43f3-92bf-15656e7fb181">

- 인증 문서화 자동화
  - 기존
    - 핸들러(컨트롤러) 메서드에 다음과 같은 어노테이션을 붙여야 인증 문서화가 가능했다.<br>
        <img width="397" alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/11389a8c-e7a2-4f6d-b8ab-1f097458d5d4">

    - 국내, 해외 통틀어 자료가 아예 없다.
  - 현재
    - 컨트롤러에 문서화 어노테이션 추가 없이
    - 메서드 인자 혹은 메서드 인자에 붙은 어노테이션을 인식하여 인증을 문서화한다.
      - 우리 서비스의 경우 `@Auth` 어노테이션 활용
      - `OpenApiConfig.java` 에 관련 내용 구현
