### PR TITLE
fix: API문서에 서버 주소 명시

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/digginroom/digginroom/config/OpenApiConfig.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import io.swagger.v3.oas.models.servers.Server;
 import java.util.Arrays;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.utils.SpringDocUtils;
@@ -40,7 +41,8 @@ public class OpenApiConfig {
                                 SESSION_SECURITY_KEY,
                                 sessionSecurityScheme()
                         )
-                );
+                )
+                .addServersItem(new Server().url("/"));
     }
 
     private SecurityScheme sessionSecurityScheme() {


### PR DESCRIPTION
## 관련 이슈번호
- #229

## 작업 사항
<img width="601" alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/99f456af-5ea7-4bb9-a9b1-9c895ffc7231">

Try it out 기능 사용을 위해 서버 주소 명시, 없으면 Mixed Content 오류 (HTTPS -> HTTP로 요청하기 때문)


## 기타 사항
<br/>
