### PR TITLE
feat: 사용자 정보를 가져온다

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/controller/MemberOperationController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/MemberOperationController.java
@@ -1,9 +1,11 @@
 package com.digginroom.digginroom.controller;
 
 import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
 import com.digginroom.digginroom.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +25,10 @@ public class MemberOperationController {
     ) {
         memberService.markFavorite(memberId, favoriteGenresRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberDetailsResponse> showMemberDetails(@Auth final Long memberId) {
+        return ResponseEntity.ok().body(memberService.getMemberDetails(memberId));
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/MemberDetailsResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/MemberDetailsResponse.java
@@ -1,0 +1,14 @@
+package com.digginroom.digginroom.controller.dto;
+
+import com.digginroom.digginroom.domain.Member;
+
+public record MemberDetailsResponse(Long memberId, String username, boolean hasFavorite) {
+
+    public static MemberDetailsResponse of(final Member member) {
+        return new MemberDetailsResponse(
+                member.getId(),
+                member.getUsername(),
+                member.hasFavorite()
+        );
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/MemberLoginResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/MemberLoginResponse.java
@@ -4,7 +4,7 @@ import com.digginroom.digginroom.domain.Member;
 
 public record MemberLoginResponse(Long memberId, boolean hasFavorite) {
 
-    public static MemberLoginResponse of(Member member) {
+    public static MemberLoginResponse of(final Member member) {
         return new MemberLoginResponse(
                 member.getId(),
                 member.hasFavorite()

--- a/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
@@ -2,6 +2,7 @@ package com.digginroom.digginroom.service;
 
 import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
 import com.digginroom.digginroom.controller.dto.GoogleOAuthRequest;
+import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
 import com.digginroom.digginroom.controller.dto.MemberDuplicationResponse;
 import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
 import com.digginroom.digginroom.controller.dto.MemberLoginResponse;
@@ -56,6 +57,11 @@ public class MemberService {
     public Member findMember(final Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(NotFoundException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberDetailsResponse getMemberDetails(final Long id) {
+        return MemberDetailsResponse.of(findMember(id));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/digginroom/digginroom/controller/MemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/MemberArgumentResolverTest.java
@@ -1,0 +1,43 @@
+package com.digginroom.digginroom.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+
+import com.digginroom.digginroom.controller.dto.ErrorResponse;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class MemberArgumentResolverTest extends ControllerTest {
+
+    @Test
+    void 세션_정보가_없는_경우_예외를_던진다() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/member/me")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("timeStamp", Matchers.notNullValue())
+                .body("errorMessage", equalTo("회원 인증 정보가 존재하지 않습니다."))
+                .extract().as(ErrorResponse.class);
+    }
+
+    @Test
+    void 세션_정보가_잘못된_경우_예외를_던진다() {
+        RestAssured.given().log().all()
+                .cookie("JSESSIONID", "anything")
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/member/me")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("timeStamp", Matchers.notNullValue())
+                .body("errorMessage", equalTo("회원 인증 정보가 존재하지 않습니다."))
+                .extract().as(ErrorResponse.class);
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/controller/MemberOperationControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/MemberOperationControllerTest.java
@@ -6,10 +6,12 @@ import static com.digginroom.digginroom.domain.Genre.RNB;
 import static com.digginroom.digginroom.domain.Genre.ROCK;
 
 import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.util.List;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -97,5 +99,20 @@ class MemberOperationControllerTest extends ControllerTest {
                 .post("/member/favorite-genres")
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 아이디_유저네임_취향정보수집여부를_포함한_회원정보를_응답한다() {
+        RestAssured.given().log().all()
+                .cookie(cookie)
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/member/me")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("memberId", Matchers.notNullValue())
+                .body("username", Matchers.notNullValue())
+                .body("hasFavorite", Matchers.notNullValue())
+                .extract().as(MemberDetailsResponse.class);
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
@@ -149,4 +149,14 @@ class MemberServiceTest {
 
         assertThat(member.hasFavorite()).isTrue();
     }
+
+    @Test
+    void 아이디_유저네임_취향정보수집여부를_포함한_회원정보를_반환한다() {
+        Member member = 파워();
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+
+        assertThat(memberService.getMemberDetails(member.getId()))
+                .extracting("memberId", "username", "hasFavorite")
+                .containsExactly(member.getId(), member.getUsername(), member.hasFavorite());
+    }
 }


### PR DESCRIPTION
## 관련 이슈번호
- #234 

## 작업 사항
- 사용자 정보를 가져오는 기능을 구현
  - `memberId`, `username`, `hasFavorite `전달
  - <img width="684" alt="image" src="https://github.com/woowacourse-teams/2023-diggin-room/assets/39221443/5af360a8-7f73-419c-88fb-c2ca9ae964b9">


## 기타 사항
- 세션 아이디를 검증하는 테스트 구현(`MemberArgumentResolverTest`)