### PR TITLE
feat: 댓글 조회 API에 자신의 댓글 여부를 추가

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/admin/controller/UploadController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/admin/controller/UploadController.java
@@ -1,8 +1,8 @@
 package com.digginroom.digginroom.admin.controller;
 
 import com.digginroom.digginroom.admin.controller.dto.UploadRequest;
-import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.admin.service.UploadService;
+import com.digginroom.digginroom.domain.Genre;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
@@ -31,7 +31,7 @@ public class CommentController {
             @Auth final Long loginMemberId,
             @PathVariable final Long roomId
     ) {
-        CommentsResponse roomComments = roomService.findRoomComments(roomId);
+        CommentsResponse roomComments = roomService.findRoomComments(roomId, loginMemberId);
         return ResponseEntity.status(OK).body(roomComments);
     }
 
@@ -57,12 +57,12 @@ public class CommentController {
     }
 
     @DeleteMapping("/{roomId}/comments/{commentId}")
-    public ResponseEntity<CommentResponse> delete(
+    public ResponseEntity<Void> delete(
             @Auth final Long loginMemberId,
             @PathVariable final Long roomId,
             @PathVariable final Long commentId
     ) {
         roomService.deleteComment(roomId, loginMemberId, commentId);
-        return ResponseEntity.status(OK).build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/CommentResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/CommentResponse.java
@@ -8,16 +8,18 @@ public record CommentResponse(
         String writer,
         String comment,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        boolean isOwner
 ) {
 
-    public static CommentResponse of(final Comment comment) {
+    public static CommentResponse of(final Comment comment, boolean isOwner) {
         return new CommentResponse(
                 comment.getId(),
                 comment.getMember().getUsername(),
                 comment.getComment(),
                 comment.getCreatedAt(),
-                comment.getUpdatedAt()
+                comment.getUpdatedAt(),
+                isOwner
         );
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
@@ -21,10 +21,10 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
 
-    public CommentsResponse getRoomComments(final Long roomId) {
+    public CommentsResponse getRoomComments(final Long roomId, final Member member) {
         List<Comment> comments = commentRepository.findCommentsByRoomId(roomId);
         return new CommentsResponse(comments.stream()
-                .map(CommentResponse::of)
+                .map(comment -> CommentResponse.of(comment, comment.isOwner(member)))
                 .toList());
     }
 
@@ -32,7 +32,7 @@ public class CommentService {
         Comment comment = new Comment(roomId, request.comment(), member);
         commentRepository.save(comment);
 
-        return CommentResponse.of(comment);
+        return CommentResponse.of(comment, comment.isOwner(member));
     }
 
     public void delete(final Long roomId, final Member member, final Long commentId) {

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -104,9 +104,10 @@ public class RoomService {
         member.undislike(room);
     }
 
-    public CommentsResponse findRoomComments(final Long roomId) {
+    public CommentsResponse findRoomComments(final Long roomId, final Long loginMemberId) {
         validateExistRoom(roomId);
-        return commentService.getRoomComments(roomId);
+        Member member = memberService.findMember(loginMemberId);
+        return commentService.getRoomComments(roomId, member);
     }
 
     public void validateExistRoom(final Long roomId) {
@@ -136,6 +137,6 @@ public class RoomService {
         validateExistRoom(roomId);
         Member member = memberService.findMember(memberId);
         Comment updateComment = commentService.update(member, roomId, commentId, request);
-        return CommentResponse.of(updateComment);
+        return CommentResponse.of(updateComment, updateComment.isOwner(member));
     }
 }


### PR DESCRIPTION
## 관련 이슈번호
- #255 

## 작업 사항
댓글 API(조회, 등록, 수정)에 요청 유저가 해당 댓글의 주인인지 boolean 타입 필드 추가

## 기타 사항
