### PR TITLE
refactor: 룸 업로드 페이지 리팩터링

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/admin/controller/UploadController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/admin/controller/UploadController.java
@@ -5,9 +5,9 @@ import com.digginroom.digginroom.admin.service.UploadService;
 import com.digginroom.digginroom.domain.Genre;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,14 +30,9 @@ public class UploadController {
     }
 
     @PostMapping("/upload")
-    public String upload(@Valid @ModelAttribute("request") final UploadRequest request,
-                         final BindingResult bindingResult) {
-        if (bindingResult.hasErrors()) {
-            return "uploadForm";
-        }
-
+    public ResponseEntity<Void> upload(@Valid @ModelAttribute("request") final UploadRequest request) {
         uploadService.save(request);
 
-        return "redirect:/upload";
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/admin/controller/dto/UploadRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/admin/controller/dto/UploadRequest.java
@@ -3,13 +3,14 @@ package com.digginroom.digginroom.admin.controller.dto;
 import com.digginroom.digginroom.domain.Genre;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record UploadRequest(
-        @NotBlank String title,
-        @NotBlank String artist,
+        @NotBlank @Size(min = 1, max = 255) String title,
+        @NotBlank @Size(min = 1, max = 255) String artist,
         @NotNull Genre superGenre,
-        String description,
-        String subGenre,
-        @NotBlank String youtubeVideoId
+        @Size(max = 500) String description,
+        @Size(max = 255) String subGenre,
+        @NotBlank @Size(min = 1, max = 255) String youtubeVideoId
 ) {
 }

--- a/backend/src/main/resources/templates/uploadForm.html
+++ b/backend/src/main/resources/templates/uploadForm.html
@@ -5,14 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="">
-    <meta name="author" content="Mark Otto, Jacob Thornton, 그리고 Bootstrap 기여자들">
-    <meta name="generator" content="Hugo 0.88.1">
-    <title>Modals · Bootstrap v5.1</title>
-
+    <title>디깅룸 룸 업로드 페이지</title>
     <link rel="canonical" href="https://getbootstrap.kr/docs/5.1/examples/modals/">
-
-    <!-- Bootstrap core CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
     <meta name="theme-color" content="#7952b3">
@@ -32,28 +26,34 @@
                             <li>
                                 <div class="mb-3">
                                     <label class="form-label">제목</label>
-                                    <input type="text" th:field="*{title}" th:class="${#fields.hasErrors('title')}? 'form-control is-invalid' : 'form-control'">
-                                    <label class="form-label text-danger" th:if="${#fields.hasErrors('title')}">제목은 필수값 입니다</label>
+                                    <input type="text" id="title" th:field="*{title}"
+                                           th:class="${#fields.hasErrors('title')}? 'form-control is-invalid' : 'form-control'">
                                 </div>
+                                <label class="form-label text-danger" id="titleError" style="display: none"></label>
                             </li>
                             <li>
                                 <div class="mb-3">
                                     <label class="form-label">가수</label>
-                                    <input type="text" th:field="*{artist}" th:class="${#fields.hasErrors('artist')}? 'form-control is-invalid' : 'form-control'">
-                                    <label class="form-label text-danger" th:if="${#fields.hasErrors('artist')}">가수는 필수값 입니다</label>
+                                    <input type="text" id="artist" th:field="*{artist}"
+                                           th:class="${#fields.hasErrors('artist')}? 'form-control is-invalid' : 'form-control'">
                                 </div>
+                                <label class="form-label text-danger" id="artistError" style="display: none"></label>
                             </li>
                             <li>
                                 <div class="mb-3">
                                     <label class="form-label">설명</label>
-                                    <textarea class="form-control" rows="3" th:field="*{description}"></textarea>
+                                    <textarea class="form-control" rows="3" id="description"
+                                              th:field="*{description}"></textarea>
                                 </div>
+                                <label class="form-label text-danger" id="descriptionError"
+                                       style="display: none"></label>
                             </li>
                             <li>
                                 <div class="mb-3">
                                     <label class="form-label">메인 장르</label>
                                     <select class="form-select" id="floatingSelect"
-                                            aria-label="Floating label select example" th:field="*{superGenre}" required>
+                                            aria-label="Floating label select example" th:field="*{superGenre}"
+                                            required>
                                         <option th:each="colorOpt : ${genre}"
                                                 th:value="${colorOpt}" th:text="${colorOpt.getName()}"></option>
                                     </select>
@@ -62,8 +62,9 @@
                             <li>
                                 <div class="mb-3">
                                     <label class="form-label">서브 장르</label>
-                                    <input type="text" class="form-control" th:field="*{subGenre}">
+                                    <input type="text" id="subGenre" class="form-control" th:field="*{subGenre}">
                                 </div>
+                                <label class="form-label text-danger" id="subGenreError" style="display: none"></label>
                             </li>
                             <li>
                                 <label class="form-label">유튜브 영상 아이디</label>
@@ -74,17 +75,30 @@
                                         <path d="M8.051 1.999h.089c.822.003 4.987.033 6.11.335a2.01 2.01 0 0 1 1.415 1.42c.101.38.172.883.22 1.402l.01.104.022.26.008.104c.065.914.073 1.77.074 1.957v.075c-.001.194-.01 1.108-.082 2.06l-.008.105-.009.104c-.05.572-.124 1.14-.235 1.558a2.007 2.007 0 0 1-1.415 1.42c-1.16.312-5.569.334-6.18.335h-.142c-.309 0-1.587-.006-2.927-.052l-.17-.006-.087-.004-.171-.007-.171-.007c-1.11-.049-2.167-.128-2.654-.26a2.007 2.007 0 0 1-1.415-1.419c-.111-.417-.185-.986-.235-1.558L.09 9.82l-.008-.104A31.4 31.4 0 0 1 0 7.68v-.123c.002-.215.01-.958.064-1.778l.007-.103.003-.052.008-.104.022-.26.01-.104c.048-.519.119-1.023.22-1.402a2.007 2.007 0 0 1 1.415-1.42c.487-.13 1.544-.21 2.654-.26l.17-.007.172-.006.086-.003.171-.007A99.788 99.788 0 0 1 7.858 2h.193zM6.4 5.209v4.818l4.157-2.408L6.4 5.209z"></path>
                                     </svg>
                                 </span>
-                                    <input type="text" placeholder="Youtube Video ID"
+                                    <input type="text" id="youtubeVideoId" placeholder="Youtube Video ID"
                                            aria-label="Input group example"
-                                           aria-describedby="basic-addon1" th:field="*{youtubeVideoId}" th:class="${#fields.hasErrors('youtubeVideoId')}? 'form-control is-invalid' : 'form-control'">
+                                           aria-describedby="basic-addon1" th:field="*{youtubeVideoId}"
+                                           th:class="${#fields.hasErrors('youtubeVideoId')}? 'form-control is-invalid' : 'form-control'">
                                 </div>
-                                <label class="form-label text-danger" th:if="${#fields.hasErrors('youtubeVideoId')}">Youtube Video Id는 필수값 입니다</label>
+                                <label class="form-label text-danger" id="youtubeVideoIdError"
+                                       style="display: none"></label>
                             </li>
                         </ul>
                         <button type="submit" class="mt-3 btn btn-lg btn-primary w-100" data-bs-dismiss="modal">등록
                         </button>
                     </table>
                 </form>
+                <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 5">
+                    <div id="toastNotification" class="toast hide" role="alert" aria-live="assertive"
+                         aria-atomic="true">
+                        <div class="toast-header">
+                            <strong class="me-auto">알림</strong>
+                            <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+                        </div>
+                        <div class="toast-body">
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -95,5 +109,99 @@
         crossorigin="anonymous"></script>
 
 </body>
+<script>
+    const fields = {
+        '#title': {maxLength: 255, required: true, label: '제목은'},
+        '#artist': {maxLength: 255, required: true, label: '가수는'},
+        '#youtubeVideoId': {maxLength: 255, required: true, label: '유튜브 ID는'},
+        '#description': {maxLength: 500, label: '설명은'},
+        '#subGenre': {maxLength: 255, label: '세부 장르는'}
+    };
 
+    const errorSuffix = "Error";
+
+    const getElement = selector => document.querySelector(selector);
+
+    const validateField = elementId => {
+        const field = fields[elementId];
+        const value = getElement(elementId).value;
+
+        if (!value && field.required) {
+            setError(elementId, `${field.label} 필수입니다.`);
+            return false;
+        }
+
+        if (value.length > field.maxLength) {
+            setError(elementId, `${field.label} ${field.maxLength}자를 넘길 수 없습니다.`);
+            return false;
+        }
+
+        clearError(elementId);
+        return true;
+    };
+
+    const setError = (elementId, message) => {
+        getElement(elementId + errorSuffix).textContent = message;
+        getElement(elementId + errorSuffix).style.display = 'block';
+    };
+
+    const clearError = elementId => {
+        getElement(elementId + errorSuffix).style.display = 'none';
+    };
+
+    const showToastNotification = (message, isSuccess) => {
+        const toast = new bootstrap.Toast(getElement('#toastNotification'));
+        const toastBody = getElement('.toast-body');
+        toastBody.textContent = message;
+        toastBody.style.color = isSuccess ? 'green' : 'red';
+        toast.show();
+    };
+
+    const clearForm = () => {
+        Object.keys(fields).forEach(tag => getElement(tag).value = '');
+    };
+
+    const isFormValid = () => {
+        let isAllFieldValid = true;
+        Object.keys(fields).forEach(elementId => {
+            if (!validateField(elementId)) {
+                isAllFieldValid = false;
+            }
+        });
+        return isAllFieldValid;
+    };
+
+    const upload = event => {
+        event.preventDefault();
+
+        if (!isFormValid()) {
+            showToastNotification('입력란을 다시 확인해주세요.', false);
+            return;
+        }
+
+        const formData = new FormData(event.target);
+        fetch('/upload', {
+            method: 'POST',
+            body: formData
+        })
+            .then(response => {
+                if (response.ok) {
+                    showToastNotification('업로드 성공', true);
+                    clearForm();
+                } else {
+                    showToastNotification(`업로드 실패 ${response.status}`, false);
+                }
+            })
+            .catch(error => {
+                showToastNotification(`업로드 실패 ${error}`, false);
+            });
+    };
+
+    (() => {
+        Object.keys(fields).forEach(elementId => {
+            getElement(elementId).addEventListener('keyup', () => validateField(elementId));
+        });
+        getElement('form').addEventListener('submit', upload);
+    })();
+</script>
 </html>


### PR DESCRIPTION
## 관련 이슈번호
- #306 

## 작업 사항
#### 룸 업로드 성공 시 🚀
- 룸에 대한 업로드가 성공적으로 이루어지면 기존 선택한 슈퍼장르 유지
- 나머지 필드에 대해서는 입력란을 초기화
- 우측 하단에 업로드 성공 문구 출력
#### 룸 업로드 실패 시 🥲
- 기존 각 필드의 필수값, 최대값을 넘길 시 프론트 단에서 1차적으로 경고메시지 출력 후 요청 중단
- 실제 서버에서 필수 값 및 글자수 검증 실패 시 우측 하단에 400 문구 출력
- 다른 이유로 (중복 노래 추가 혹은 서버 장애 등) 업로드 실패 시 우측 하단에 500 문구 출력
## 기타 사항
#### 자바스크립트 파일 분리
- 현재 프론트 페이지에 `<script>` 태그안에 자바스크립트 코드가 존재합니다.
- 처음에는 별도의 파일로 분리를 고려했습니다. 
   - 단, 하나의 자바스크립트 파일을 서빙하기 위해서 스프링단에 `addResouceHandler` 를 오버라이드 해야하는 점이 있습니다.
- 하나의 파일만을 위해서 별도의 핸들러를 넣는것이 과하다고 생각해서 일단은 `<script>` 태그 안에 js 코드를 넣어두었습니다.

#### 중복 룸 업로드 검증 필요
현재 룸 추가 요청 시 요청한 타이틀과 가수가 이미 데이터베이스에 있는 경우 두 값이 복합키가 걸려있으므로 예외가 발생합니다.
현재 급한 것은 아니기 때문에 리팩터링 사항에 추가 후 추후 해당 검증 기능을 추가할 필요가 있습니다.
