### PR TITLE
refactor: DTO 패키지 이동 및 각 서비스간 의존을 제거한다.

### DIFF
--- a/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
@@ -52,7 +52,7 @@ public class CommentController {
             @PathVariable final Long commentId,
             @Valid @RequestBody final CommentRequest request
     ) {
-        CommentResponse response = commentService.update(roomId, loginMemberId, commentId, request);
+        CommentResponse response = commentService.update(loginMemberId, commentId, request);
         return ResponseEntity.status(OK).body(response);
     }
 
@@ -62,7 +62,7 @@ public class CommentController {
             @PathVariable final Long roomId,
             @PathVariable final Long commentId
     ) {
-        commentService.delete(roomId, loginMemberId, commentId);
+        commentService.delete(loginMemberId, commentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
@@ -3,10 +3,10 @@ package com.digginroom.digginroom.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.digginroom.digginroom.service.CommentService;
 import com.digginroom.digginroom.service.dto.CommentRequest;
 import com.digginroom.digginroom.service.dto.CommentResponse;
 import com.digginroom.digginroom.service.dto.CommentsResponse;
-import com.digginroom.digginroom.service.RoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,14 +24,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/rooms")
 public class CommentController {
 
-    private final RoomService roomService;
+    private final CommentService commentService;
 
     @GetMapping("/{roomId}/comments")
     public ResponseEntity<CommentsResponse> findRoomComments(
             @Auth final Long loginMemberId,
             @PathVariable final Long roomId
     ) {
-        CommentsResponse roomComments = roomService.findRoomComments(roomId, loginMemberId);
+        CommentsResponse roomComments = commentService.getRoomComments(roomId, loginMemberId);
         return ResponseEntity.status(OK).body(roomComments);
     }
 
@@ -41,7 +41,7 @@ public class CommentController {
             @PathVariable final Long roomId,
             @Valid @RequestBody final CommentRequest request
     ) {
-        CommentResponse response = roomService.comment(roomId, loginMemberId, request);
+        CommentResponse response = commentService.comment(roomId, loginMemberId, request);
         return ResponseEntity.status(CREATED).body(response);
     }
 
@@ -52,7 +52,7 @@ public class CommentController {
             @PathVariable final Long commentId,
             @Valid @RequestBody final CommentRequest request
     ) {
-        CommentResponse response = roomService.updateComment(roomId, loginMemberId, commentId, request);
+        CommentResponse response = commentService.update(roomId, loginMemberId, commentId, request);
         return ResponseEntity.status(OK).body(response);
     }
 
@@ -62,7 +62,7 @@ public class CommentController {
             @PathVariable final Long roomId,
             @PathVariable final Long commentId
     ) {
-        roomService.deleteComment(roomId, loginMemberId, commentId);
+        commentService.delete(roomId, loginMemberId, commentId);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/CommentController.java
@@ -3,9 +3,9 @@ package com.digginroom.digginroom.controller;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-import com.digginroom.digginroom.controller.dto.CommentRequest;
-import com.digginroom.digginroom.controller.dto.CommentResponse;
-import com.digginroom.digginroom.controller.dto.CommentsResponse;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.CommentResponse;
+import com.digginroom.digginroom.service.dto.CommentsResponse;
 import com.digginroom.digginroom.service.RoomService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
-import com.digginroom.digginroom.controller.dto.ErrorResponse;
+import com.digginroom.digginroom.service.dto.ErrorResponse;
 import com.digginroom.digginroom.exception.DigginRoomException;
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/MemberJoinController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/MemberJoinController.java
@@ -1,7 +1,7 @@
 package com.digginroom.digginroom.controller;
 
-import com.digginroom.digginroom.controller.dto.MemberDuplicationResponse;
-import com.digginroom.digginroom.controller.dto.MemberSaveRequest;
+import com.digginroom.digginroom.service.dto.MemberDuplicationResponse;
+import com.digginroom.digginroom.service.dto.MemberSaveRequest;
 import com.digginroom.digginroom.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/MemberLoginController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/MemberLoginController.java
@@ -1,8 +1,8 @@
 package com.digginroom.digginroom.controller;
 
-import com.digginroom.digginroom.controller.dto.IdTokenRequest;
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
-import com.digginroom.digginroom.controller.dto.MemberLoginResponse;
+import com.digginroom.digginroom.service.dto.IdTokenRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginResponse;
 import com.digginroom.digginroom.service.MemberService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/MemberOperationController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/MemberOperationController.java
@@ -1,7 +1,7 @@
 package com.digginroom.digginroom.controller;
 
-import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
-import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
+import com.digginroom.digginroom.service.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.service.dto.MemberDetailsResponse;
 import com.digginroom.digginroom.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/RoomController.java
@@ -1,8 +1,8 @@
 package com.digginroom.digginroom.controller;
 
-import com.digginroom.digginroom.controller.dto.RoomRequest;
-import com.digginroom.digginroom.controller.dto.RoomResponse;
-import com.digginroom.digginroom.controller.dto.RoomsResponse;
+import com.digginroom.digginroom.service.dto.RoomRequest;
+import com.digginroom.digginroom.service.dto.RoomResponse;
+import com.digginroom.digginroom.service.dto.RoomsResponse;
 import com.digginroom.digginroom.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/com/digginroom/digginroom/controller/dto/RoomRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/controller/dto/RoomRequest.java
@@ -1,4 +1,0 @@
-package com.digginroom.digginroom.controller.dto;
-
-public record RoomRequest(Long roomId) {
-}

--- a/backend/src/main/java/com/digginroom/digginroom/domain/comment/Comment.java
+++ b/backend/src/main/java/com/digginroom/digginroom/domain/comment/Comment.java
@@ -2,6 +2,7 @@ package com.digginroom.digginroom.domain.comment;
 
 import com.digginroom.digginroom.domain.BaseEntity;
 import com.digginroom.digginroom.domain.member.Member;
+import com.digginroom.digginroom.exception.CommentException.NotOwnerException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
@@ -22,15 +23,14 @@ public class Comment extends BaseEntity {
     @ManyToOne
     private Member member;
 
-    public void updateComment(final String comment) {
+    public void updateComment(final String comment, final Member member) {
+        if (!isOwner(member)) {
+            throw new NotOwnerException();
+        }
         this.comment = comment;
     }
 
     public boolean isOwner(final Member member) {
         return this.member.equals(member);
-    }
-
-    public boolean isSameRoom(final Long roomId) {
-        return this.roomId.equals(roomId);
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/repository/MemberRepository.java
+++ b/backend/src/main/java/com/digginroom/digginroom/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.digginroom.digginroom.repository;
 
 import com.digginroom.digginroom.domain.member.Member;
+import com.digginroom.digginroom.exception.MemberException.NotFoundException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByUsername(final String username);
 
     Optional<Member> findMemberByUsername(final String username);
+
+    default Member getMemberByUsername(final String username) {
+        return findMemberByUsername(username).orElseThrow(NotFoundException::new);
+    }
+
+    default Member getMemberById(final Long id) {
+        return findById(id).orElseThrow(NotFoundException::new);
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/repository/RoomRepository.java
+++ b/backend/src/main/java/com/digginroom/digginroom/repository/RoomRepository.java
@@ -2,6 +2,7 @@ package com.digginroom.digginroom.repository;
 
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.room.Room;
+import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +10,9 @@ import java.util.List;
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     List<Room> findByTrackSuperGenre(final Genre superGenre);
+
+    default Room getRoomById(final Long id) {
+        return findById(id)
+                .orElseThrow(() -> new NotFoundException(id));
+    }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
@@ -2,9 +2,9 @@ package com.digginroom.digginroom.service;
 
 import static com.digginroom.digginroom.exception.CommentException.NotOwnerException;
 
-import com.digginroom.digginroom.controller.dto.CommentRequest;
-import com.digginroom.digginroom.controller.dto.CommentResponse;
-import com.digginroom.digginroom.controller.dto.CommentsResponse;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.CommentResponse;
+import com.digginroom.digginroom.service.dto.CommentsResponse;
 import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.exception.CommentException.NotSameRoomException;

--- a/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
@@ -4,7 +4,6 @@ import static com.digginroom.digginroom.exception.CommentException.NotOwnerExcep
 
 import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
-import com.digginroom.digginroom.exception.CommentException.NotSameRoomException;
 import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import com.digginroom.digginroom.repository.CommentRepository;
 import com.digginroom.digginroom.repository.MemberRepository;
@@ -50,30 +49,12 @@ public class CommentService {
         }
     }
 
-    public void delete(final Long roomId, final Long memberId, final Long commentId) {
+    public void delete(final Long memberId, final Long commentId) {
         Member member = memberRepository.getMemberById(memberId);
         Comment comment = commentRepository.getCommentById(commentId);
 
-        validateWriteable(comment, member, roomId);
-        commentRepository.delete(comment);
-    }
-
-    public CommentResponse update(
-            final Long roomId,
-            final Long memberId,
-            final Long commentId,
-            final CommentRequest request
-    ) {
-        Member member = memberRepository.getMemberById(memberId);
-        Comment comment = commentRepository.getCommentById(commentId);
-        validateWriteable(comment, member, roomId);
-        comment.updateComment(request.comment());
-        return CommentResponse.of(comment, comment.isOwner(member));
-    }
-
-    private void validateWriteable(final Comment comment, final Member member, final Long roomId) {
-        validateSameRoom(roomId, comment);
         validateSameOwner(member, comment);
+        commentRepository.delete(comment);
     }
 
     private void validateSameOwner(final Member member, final Comment comment) {
@@ -82,9 +63,14 @@ public class CommentService {
         }
     }
 
-    private void validateSameRoom(final Long roomId, final Comment comment) {
-        if (!comment.isSameRoom(roomId)) {
-            throw new NotSameRoomException();
-        }
+    public CommentResponse update(
+            final Long memberId,
+            final Long commentId,
+            final CommentRequest request
+    ) {
+        Member member = memberRepository.getMemberById(memberId);
+        Comment comment = commentRepository.getCommentById(commentId);
+        comment.updateComment(request.comment(), member);
+        return CommentResponse.of(comment, comment.isOwner(member));
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/CommentService.java
@@ -2,13 +2,16 @@ package com.digginroom.digginroom.service;
 
 import static com.digginroom.digginroom.exception.CommentException.NotOwnerException;
 
-import com.digginroom.digginroom.service.dto.CommentRequest;
-import com.digginroom.digginroom.service.dto.CommentResponse;
-import com.digginroom.digginroom.service.dto.CommentsResponse;
 import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.exception.CommentException.NotSameRoomException;
+import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import com.digginroom.digginroom.repository.CommentRepository;
+import com.digginroom.digginroom.repository.MemberRepository;
+import com.digginroom.digginroom.repository.RoomRepository;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.CommentResponse;
+import com.digginroom.digginroom.service.dto.CommentsResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,33 +23,52 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final RoomRepository roomRepository;
 
-    public CommentsResponse getRoomComments(final Long roomId, final Member member) {
+    public CommentsResponse getRoomComments(final Long roomId, final Long memberId) {
+        Member member = memberRepository.getMemberById(memberId);
         List<Comment> comments = commentRepository.findCommentsByRoomId(roomId);
         return new CommentsResponse(comments.stream()
                 .map(comment -> CommentResponse.of(comment, comment.isOwner(member)))
                 .toList());
     }
 
-    public CommentResponse comment(final Long roomId, final Member member, final CommentRequest request) {
+    public CommentResponse comment(final Long roomId, final Long memberId, final CommentRequest request) {
+        validateExistRoom(roomId);
+        Member member = memberRepository.getMemberById(memberId);
+
         Comment comment = new Comment(roomId, request.comment(), member);
         commentRepository.save(comment);
 
         return CommentResponse.of(comment, comment.isOwner(member));
     }
 
-    public void delete(final Long roomId, final Member member, final Long commentId) {
+    public void validateExistRoom(final Long roomId) {
+        if (!roomRepository.existsById(roomId)) {
+            throw new NotFoundException(roomId);
+        }
+    }
+
+    public void delete(final Long roomId, final Long memberId, final Long commentId) {
+        Member member = memberRepository.getMemberById(memberId);
         Comment comment = commentRepository.getCommentById(commentId);
 
         validateWriteable(comment, member, roomId);
         commentRepository.delete(comment);
     }
 
-    public Comment update(final Member member, final Long roomId, final Long commentId, final CommentRequest request) {
+    public CommentResponse update(
+            final Long roomId,
+            final Long memberId,
+            final Long commentId,
+            final CommentRequest request
+    ) {
+        Member member = memberRepository.getMemberById(memberId);
         Comment comment = commentRepository.getCommentById(commentId);
         validateWriteable(comment, member, roomId);
         comment.updateComment(request.comment());
-        return comment;
+        return CommentResponse.of(comment, comment.isOwner(member));
     }
 
     private void validateWriteable(final Comment comment, final Member member, final Long roomId) {

--- a/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
@@ -1,6 +1,11 @@
 package com.digginroom.digginroom.service;
 
-import com.digginroom.digginroom.controller.dto.*;
+import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
+import com.digginroom.digginroom.controller.dto.MemberDuplicationResponse;
+import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
+import com.digginroom.digginroom.controller.dto.MemberLoginResponse;
+import com.digginroom.digginroom.controller.dto.MemberSaveRequest;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.member.Provider;
@@ -10,11 +15,10 @@ import com.digginroom.digginroom.exception.MemberException.WrongProviderExceptio
 import com.digginroom.digginroom.oauth.IdTokenResolver;
 import com.digginroom.digginroom.oauth.payload.IdTokenPayload;
 import com.digginroom.digginroom.repository.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional
@@ -43,7 +47,7 @@ public class MemberService {
     }
 
     public void markFavorite(final Long memberId, final FavoriteGenresRequest genres) {
-        Member member = findMember(memberId);
+        Member member = memberRepository.getMemberById(memberId);
 
         List<Genre> favoriteGenres = genres.favoriteGenres().stream()
                 .map(Genre::of)
@@ -53,13 +57,12 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Member findMember(final Long id) {
-        return memberRepository.findById(id)
-                .orElseThrow(NotFoundException::new);
+        return memberRepository.getMemberById(id);
     }
 
     @Transactional(readOnly = true)
     public MemberDetailsResponse getMemberDetails(final Long id) {
-        return MemberDetailsResponse.of(findMember(id));
+        return MemberDetailsResponse.of(memberRepository.getMemberById(id));
     }
 
     public MemberLoginResponse loginGuest() {
@@ -69,8 +72,7 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberLoginResponse loginMember(final MemberLoginRequest request) {
-        Member member = memberRepository.findMemberByUsername(request.username())
-                .orElseThrow(NotFoundException::new);
+        Member member = memberRepository.getMemberByUsername(request.username());
 
         if (member.getProvider() != Provider.SELF) {
             throw new WrongProviderException();

--- a/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
@@ -56,11 +56,6 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public Member findMember(final Long id) {
-        return memberRepository.getMemberById(id);
-    }
-
-    @Transactional(readOnly = true)
     public MemberDetailsResponse getMemberDetails(final Long id) {
         return MemberDetailsResponse.of(memberRepository.getMemberById(id));
     }

--- a/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/MemberService.java
@@ -1,11 +1,11 @@
 package com.digginroom.digginroom.service;
 
-import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
-import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
-import com.digginroom.digginroom.controller.dto.MemberDuplicationResponse;
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
-import com.digginroom.digginroom.controller.dto.MemberLoginResponse;
-import com.digginroom.digginroom.controller.dto.MemberSaveRequest;
+import com.digginroom.digginroom.service.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.service.dto.MemberDetailsResponse;
+import com.digginroom.digginroom.service.dto.MemberDuplicationResponse;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginResponse;
+import com.digginroom.digginroom.service.dto.MemberSaveRequest;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.member.Provider;

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -1,18 +1,22 @@
 package com.digginroom.digginroom.service;
 
-import com.digginroom.digginroom.controller.dto.*;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.room.Room;
 import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import com.digginroom.digginroom.repository.RoomRepository;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.CommentResponse;
+import com.digginroom.digginroom.service.dto.CommentsResponse;
+import com.digginroom.digginroom.service.dto.RoomResponse;
+import com.digginroom.digginroom.service.dto.RoomsResponse;
+import com.digginroom.digginroom.service.dto.TrackResponse;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @Transactional

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -3,7 +3,6 @@ package com.digginroom.digginroom.service;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.room.Room;
-import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import com.digginroom.digginroom.repository.MemberRepository;
 import com.digginroom.digginroom.repository.RoomRepository;
 import com.digginroom.digginroom.service.dto.RoomResponse;
@@ -65,31 +64,26 @@ public class RoomService {
     }
 
     public void scrap(final Long memberId, final Long roomId) {
-        Room room = findRoom(roomId);
+        Room room = roomRepository.getRoomById(roomId);
         Member member = memberRepository.getMemberById(memberId);
         member.scrap(room);
     }
 
     public void unscrap(final Long memberId, final Long roomId) {
-        Room room = findRoom(roomId);
+        Room room = roomRepository.getRoomById(roomId);
         Member member = memberRepository.getMemberById(memberId);
         member.unscrap(room);
     }
 
-    private Room findRoom(final Long roomId) {
-        return roomRepository.findById(roomId)
-                .orElseThrow(() -> new NotFoundException(roomId));
-    }
-
     public void dislike(final Long memberId, final Long roomId) {
-        Room room = findRoom(roomId);
+        Room room = roomRepository.getRoomById(roomId);
         Member member = memberRepository.getMemberById(memberId);
 
         member.dislike(room);
     }
 
     public void undislike(final Long memberId, final Long roomId) {
-        Room room = findRoom(roomId);
+        Room room = roomRepository.getRoomById(roomId);
         Member member = memberRepository.getMemberById(memberId);
 
         member.undislike(room);

--- a/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/RoomService.java
@@ -1,15 +1,11 @@
 package com.digginroom.digginroom.service;
 
 import com.digginroom.digginroom.domain.Genre;
-import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.room.Room;
 import com.digginroom.digginroom.exception.RoomException.NotFoundException;
 import com.digginroom.digginroom.repository.MemberRepository;
 import com.digginroom.digginroom.repository.RoomRepository;
-import com.digginroom.digginroom.service.dto.CommentRequest;
-import com.digginroom.digginroom.service.dto.CommentResponse;
-import com.digginroom.digginroom.service.dto.CommentsResponse;
 import com.digginroom.digginroom.service.dto.RoomResponse;
 import com.digginroom.digginroom.service.dto.RoomsResponse;
 import com.digginroom.digginroom.service.dto.TrackResponse;
@@ -26,7 +22,6 @@ public class RoomService {
 
     private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
-    private final CommentService commentService;
 
     @Transactional(readOnly = true)
     public RoomResponse recommend(final Long memberId) {
@@ -98,41 +93,5 @@ public class RoomService {
         Member member = memberRepository.getMemberById(memberId);
 
         member.undislike(room);
-    }
-
-    public CommentsResponse findRoomComments(final Long roomId, final Long loginMemberId) {
-        validateExistRoom(roomId);
-        Member member = memberRepository.getMemberById(loginMemberId);
-        return commentService.getRoomComments(roomId, member);
-    }
-
-    public void validateExistRoom(final Long roomId) {
-        if (!roomRepository.existsById(roomId)) {
-            throw new NotFoundException(roomId);
-        }
-    }
-
-    public CommentResponse comment(final Long roomId, final Long memberId, final CommentRequest request) {
-        validateExistRoom(roomId);
-        Member member = memberRepository.getMemberById(memberId);
-        return commentService.comment(roomId, member, request);
-    }
-
-    public void deleteComment(final Long roomId, final Long memberId, final Long commentId) {
-        validateExistRoom(roomId);
-        Member member = memberRepository.getMemberById(memberId);
-        commentService.delete(roomId, member, commentId);
-    }
-
-    public CommentResponse updateComment(
-            final Long roomId,
-            final Long memberId,
-            final Long commentId,
-            final CommentRequest request
-    ) {
-        validateExistRoom(roomId);
-        Member member = memberRepository.getMemberById(memberId);
-        Comment updateComment = commentService.update(member, roomId, commentId, request);
-        return CommentResponse.of(updateComment, updateComment.isOwner(member));
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/CommentRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/CommentRequest.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/CommentResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/CommentResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import com.digginroom.digginroom.domain.comment.Comment;
 import java.time.LocalDateTime;

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/CommentsResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/CommentsResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/FavoriteGenresRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/FavoriteGenresRequest.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/IdTokenRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/IdTokenRequest.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 public record IdTokenRequest(String idToken) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/KakaoOAuthRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/KakaoOAuthRequest.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 public record KakaoOAuthRequest(String idToken) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberDetailsResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberDetailsResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import com.digginroom.digginroom.domain.member.Member;
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberDuplicationResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberDuplicationResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 public record MemberDuplicationResponse(boolean isDuplicated) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberLoginRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberLoginRequest.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberLoginResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberLoginResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import com.digginroom.digginroom.domain.member.Member;
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberSaveRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/MemberSaveRequest.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import com.digginroom.digginroom.domain.member.Member;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/RoomRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/RoomRequest.java
@@ -1,0 +1,4 @@
+package com.digginroom.digginroom.service.dto;
+
+public record RoomRequest(Long roomId) {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/RoomResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/RoomResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 public record RoomResponse(Long roomId, String videoId, boolean isScrapped, Long scrapCount, TrackResponse track) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/RoomsResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/RoomsResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import java.util.List;
 

--- a/backend/src/main/java/com/digginroom/digginroom/service/dto/TrackResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/service/dto/TrackResponse.java
@@ -1,4 +1,4 @@
-package com.digginroom.digginroom.controller.dto;
+package com.digginroom.digginroom.service.dto;
 
 import com.digginroom.digginroom.domain.track.Track;
 

--- a/backend/src/test/java/com/digginroom/digginroom/TestFixture.java
+++ b/backend/src/test/java/com/digginroom/digginroom/TestFixture.java
@@ -1,8 +1,8 @@
 package com.digginroom.digginroom;
 
-import com.digginroom.digginroom.controller.dto.CommentRequest;
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
-import com.digginroom.digginroom.controller.dto.MemberSaveRequest;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.MemberSaveRequest;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.member.Provider;

--- a/backend/src/test/java/com/digginroom/digginroom/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/CommentControllerTest.java
@@ -10,10 +10,10 @@ import static com.digginroom.digginroom.TestFixture.파워;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.digginroom.digginroom.TestFixture;
-import com.digginroom.digginroom.controller.dto.CommentRequest;
-import com.digginroom.digginroom.controller.dto.CommentResponse;
-import com.digginroom.digginroom.controller.dto.CommentsResponse;
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.CommentResponse;
+import com.digginroom.digginroom.service.dto.CommentsResponse;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
 import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.room.Room;

--- a/backend/src/test/java/com/digginroom/digginroom/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/CommentControllerTest.java
@@ -10,16 +10,16 @@ import static com.digginroom.digginroom.TestFixture.파워;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.digginroom.digginroom.TestFixture;
-import com.digginroom.digginroom.service.dto.CommentRequest;
-import com.digginroom.digginroom.service.dto.CommentResponse;
-import com.digginroom.digginroom.service.dto.CommentsResponse;
-import com.digginroom.digginroom.service.dto.MemberLoginRequest;
 import com.digginroom.digginroom.domain.comment.Comment;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.room.Room;
 import com.digginroom.digginroom.repository.CommentRepository;
 import com.digginroom.digginroom.repository.MemberRepository;
 import com.digginroom.digginroom.repository.RoomRepository;
+import com.digginroom.digginroom.service.dto.CommentRequest;
+import com.digginroom.digginroom.service.dto.CommentResponse;
+import com.digginroom.digginroom.service.dto.CommentsResponse;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
@@ -180,7 +180,7 @@ class CommentControllerTest extends ControllerTest {
     void 유저는_자신의_댓글을_수정할_수_있다() {
         Comment comment = commentRepository.save(new Comment(나무.getId(), "댓글1", 파워));
         String cookie = login(MEMBER_LOGIN_REQUEST);
-        System.out.println("쿠키" + cookie);
+
         RestAssured.given().log().all()
                 .cookie(cookie)
                 .contentType(ContentType.JSON)
@@ -192,19 +192,5 @@ class CommentControllerTest extends ControllerTest {
 
         Comment updatedComment = commentRepository.getCommentById(comment.getId());
         assertThat(updatedComment.getComment()).isEqualTo(COMMENT_UPDATE_REQUEST.comment());
-    }
-
-    @Test
-    void 유저가_수정요청한_룸의_댓글이_해당_댓글의_룸과_다르면_안된다() {
-        Comment comment = commentRepository.save(new Comment(나무.getId(), "댓글1", 파워));
-        String cookie = login(MEMBER_LOGIN_REQUEST);
-
-        RestAssured.given().log().all()
-                .cookie(cookie)
-                .contentType(ContentType.JSON)
-                .body(COMMENT_UPDATE_REQUEST)
-                .when().patch("/rooms/" + 차이.getId() + "/comments/" + comment.getId())
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/CommentControllerTest.java
@@ -180,7 +180,7 @@ class CommentControllerTest extends ControllerTest {
     void 유저는_자신의_댓글을_수정할_수_있다() {
         Comment comment = commentRepository.save(new Comment(나무.getId(), "댓글1", 파워));
         String cookie = login(MEMBER_LOGIN_REQUEST);
-
+        System.out.println("쿠키" + cookie);
         RestAssured.given().log().all()
                 .cookie(cookie)
                 .contentType(ContentType.JSON)

--- a/backend/src/test/java/com/digginroom/digginroom/controller/MemberArgumentResolverTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/MemberArgumentResolverTest.java
@@ -2,7 +2,7 @@ package com.digginroom.digginroom.controller;
 
 import static org.hamcrest.Matchers.equalTo;
 
-import com.digginroom.digginroom.controller.dto.ErrorResponse;
+import com.digginroom.digginroom.service.dto.ErrorResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;

--- a/backend/src/test/java/com/digginroom/digginroom/controller/MemberLoginControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/MemberLoginControllerTest.java
@@ -1,6 +1,6 @@
 package com.digginroom.digginroom.controller;
 
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
 import com.digginroom.digginroom.repository.MemberRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;

--- a/backend/src/test/java/com/digginroom/digginroom/controller/MemberOperationControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/MemberOperationControllerTest.java
@@ -6,8 +6,8 @@ import static com.digginroom.digginroom.domain.Genre.RNB;
 import static com.digginroom.digginroom.domain.Genre.ROCK;
 
 import com.digginroom.digginroom.TestFixture;
-import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
-import com.digginroom.digginroom.controller.dto.MemberDetailsResponse;
+import com.digginroom.digginroom.service.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.service.dto.MemberDetailsResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;

--- a/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/RoomControllerTest.java
@@ -10,9 +10,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.hasSize;
 
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
-import com.digginroom.digginroom.controller.dto.RoomRequest;
-import com.digginroom.digginroom.controller.dto.RoomResponse;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.RoomRequest;
+import com.digginroom.digginroom.service.dto.RoomResponse;
 import com.digginroom.digginroom.domain.room.Room;
 import com.digginroom.digginroom.repository.MemberRepository;
 import com.digginroom.digginroom.repository.RoomRepository;

--- a/backend/src/test/java/com/digginroom/digginroom/controller/dto/MemberSaveRequestTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/controller/dto/MemberSaveRequestTest.java
@@ -2,6 +2,7 @@ package com.digginroom.digginroom.controller.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.digginroom.digginroom.service.dto.MemberSaveRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;

--- a/backend/src/test/java/com/digginroom/digginroom/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/repository/CommentRepositoryTest.java
@@ -1,0 +1,25 @@
+package com.digginroom.digginroom.repository;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.digginroom.digginroom.exception.CommentException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    void 댓글_정보가_없는_경우_에러가_발생한다() {
+        assertThatThrownBy(() -> commentRepository.getCommentById(Long.MAX_VALUE))
+                .isInstanceOf(CommentException.NotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/digginroom/digginroom/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/repository/MemberRepositoryTest.java
@@ -2,9 +2,11 @@ package com.digginroom.digginroom.repository;
 
 import static com.digginroom.digginroom.TestFixture.파워;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.member.Member;
+import com.digginroom.digginroom.exception.MemberException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -40,5 +42,11 @@ class MemberRepositoryTest {
         Member found = memberRepository.findById(saved파워.getId()).get();
 
         assertThat(found.getMemberGenres()).hasSize(Genre.values().length);
+    }
+
+    @Test
+    void 회원_정보가_없는_경우_에러가_발생한다() {
+        assertThatThrownBy(() -> memberRepository.getMemberById(Long.MAX_VALUE))
+                .isInstanceOf(MemberException.NotFoundException.class);
     }
 }

--- a/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
@@ -1,23 +1,5 @@
 package com.digginroom.digginroom.service;
 
-import com.digginroom.digginroom.controller.dto.*;
-import com.digginroom.digginroom.domain.member.Member;
-import com.digginroom.digginroom.exception.MemberException;
-import com.digginroom.digginroom.oauth.IdTokenResolver;
-import com.digginroom.digginroom.repository.MemberRepository;
-import com.digginroom.digginroom.util.TestClaim;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import static com.digginroom.digginroom.TestFixture.ID_TOKEN_PAYLOAD;
 import static com.digginroom.digginroom.TestFixture.파워;
 import static com.digginroom.digginroom.domain.Genre.DANCE;
@@ -25,7 +7,27 @@ import static com.digginroom.digginroom.domain.Genre.ROCK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
+import com.digginroom.digginroom.controller.dto.MemberLoginResponse;
+import com.digginroom.digginroom.controller.dto.MemberSaveRequest;
+import com.digginroom.digginroom.domain.member.Member;
+import com.digginroom.digginroom.exception.MemberException;
+import com.digginroom.digginroom.oauth.IdTokenResolver;
+import com.digginroom.digginroom.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -70,25 +72,24 @@ class MemberServiceTest {
     @Test
     void 회원_정보가_있는_경우_멤버를_반환한다() {
         Member power = Member.self("power", "power123!");
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(power));
+        when(memberRepository.getMemberById(1L)).thenReturn(power);
 
         assertThat(memberService.findMember(1L)).isEqualTo(power);
     }
 
     @Test
     void 회원_정보가_없는_경우_에러가_발생한다() {
-        when(memberRepository.findById(1L))
-                .thenReturn(Optional.empty());
+        when(memberRepository.getMemberById(1L))
+                .thenThrow(MemberException.NotFoundException.class);
 
         assertThatThrownBy(() -> memberService.findMember(1L))
-                .isInstanceOf(MemberException.NotFoundException.class)
-                .hasMessageContaining("회원 정보가 없습니다.");
+                .isInstanceOf(MemberException.NotFoundException.class);
     }
 
     @Test
     void 회원_정보가_있다면_로그인_할_수_있다() {
         Member power = Member.self("power", "power123!");
-        when(memberRepository.findMemberByUsername("power")).thenReturn(Optional.of(power));
+        when(memberRepository.getMemberByUsername("power")).thenReturn(power);
 
         assertThat(memberService.loginMember(new MemberLoginRequest(power.getUsername(), "power123!")))
                 .isEqualTo(MemberLoginResponse.of(power));
@@ -96,22 +97,20 @@ class MemberServiceTest {
 
     @Test
     void 회원_정보가_없다면_로그인_할_수_없다() {
-        when(memberRepository.findMemberByUsername("power")).thenReturn(Optional.empty());
+        when(memberRepository.getMemberByUsername("power")).thenThrow(MemberException.NotFoundException.class);
 
         assertThatThrownBy(() -> memberService.loginMember(new MemberLoginRequest("power", "power123!")))
-                .isInstanceOf(MemberException.NotFoundException.class)
-                .hasMessageContaining("회원 정보가 없습니다.");
+                .isInstanceOf(MemberException.NotFoundException.class);
     }
 
     @Test
     void 비밀번호가_틀리면_로그인_할_수_없다() {
         Member power = Member.self("power", "power123!");
-        when(memberRepository.findMemberByUsername("power")).thenReturn(Optional.of(power));
+        when(memberRepository.getMemberByUsername("power")).thenReturn(power);
 
         assertThatThrownBy(() -> memberService.loginMember(
                 new MemberLoginRequest(power.getUsername(), power.getPassword() + "asd")))
-                .isInstanceOf(MemberException.NotFoundException.class)
-                .hasMessageContaining("회원 정보가 없습니다.");
+                .isInstanceOf(MemberException.NotFoundException.class);
     }
 
     @Test
@@ -142,7 +141,7 @@ class MemberServiceTest {
     @Test
     void 취향_정보를_입력한다() {
         Member member = 파워();
-        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(memberRepository.getMemberById(member.getId())).thenReturn(member);
 
         memberService.markFavorite(member.getId(), new FavoriteGenresRequest(List.of(DANCE.getName(), ROCK.getName())));
 
@@ -152,7 +151,7 @@ class MemberServiceTest {
     @Test
     void 아이디_유저네임_취향정보수집여부를_포함한_회원정보를_반환한다() {
         Member member = 파워();
-        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+        when(memberRepository.getMemberById(member.getId())).thenReturn(member);
 
         assertThat(memberService.getMemberDetails(member.getId()))
                 .extracting("memberId", "username", "hasFavorite")

--- a/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
@@ -70,23 +70,6 @@ class MemberServiceTest {
     }
 
     @Test
-    void 회원_정보가_있는_경우_멤버를_반환한다() {
-        Member power = Member.self("power", "power123!");
-        when(memberRepository.getMemberById(1L)).thenReturn(power);
-
-        assertThat(memberService.findMember(1L)).isEqualTo(power);
-    }
-
-    @Test
-    void 회원_정보가_없는_경우_에러가_발생한다() {
-        when(memberRepository.getMemberById(1L))
-                .thenThrow(MemberException.NotFoundException.class);
-
-        assertThatThrownBy(() -> memberService.findMember(1L))
-                .isInstanceOf(MemberException.NotFoundException.class);
-    }
-
-    @Test
     void 회원_정보가_있다면_로그인_할_수_있다() {
         Member power = Member.self("power", "power123!");
         when(memberRepository.getMemberByUsername("power")).thenReturn(power);

--- a/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/MemberServiceTest.java
@@ -11,10 +11,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.digginroom.digginroom.controller.dto.FavoriteGenresRequest;
-import com.digginroom.digginroom.controller.dto.MemberLoginRequest;
-import com.digginroom.digginroom.controller.dto.MemberLoginResponse;
-import com.digginroom.digginroom.controller.dto.MemberSaveRequest;
+import com.digginroom.digginroom.service.dto.FavoriteGenresRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginRequest;
+import com.digginroom.digginroom.service.dto.MemberLoginResponse;
+import com.digginroom.digginroom.service.dto.MemberSaveRequest;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.exception.MemberException;
 import com.digginroom.digginroom.oauth.IdTokenResolver;

--- a/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
+++ b/backend/src/test/java/com/digginroom/digginroom/service/RoomServiceTest.java
@@ -7,9 +7,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import com.digginroom.digginroom.controller.dto.RoomResponse;
-import com.digginroom.digginroom.controller.dto.RoomsResponse;
-import com.digginroom.digginroom.controller.dto.TrackResponse;
+import com.digginroom.digginroom.service.dto.RoomResponse;
+import com.digginroom.digginroom.service.dto.RoomsResponse;
+import com.digginroom.digginroom.service.dto.TrackResponse;
 import com.digginroom.digginroom.domain.Genre;
 import com.digginroom.digginroom.domain.member.Member;
 import com.digginroom.digginroom.domain.room.Room;


### PR DESCRIPTION
## 관련 이슈번호
- #331 

## 작업 사항
- DTO 패키지를 컨트롤러 패키지에서 서비스 패키지로 이동
- 서비스에서 다른 서비스를 의존하는 부분 제거
  - `CommentController -> RoomService -> CommentService` 의존 `CommentController -> CommentService` 구조로 변경
- 댓글 수정/삭제시 요청한 룸과 같은 룸인지 검증 하는 로직 제거 

## 기타 사항
- `getXXById` 메서드 네이밍
  - 현재 Id를 통해 엔티티를 가져올 때 예외를 레포지터리에서 터트리도록 `getXXById` 메서드를 각 레포지터리에 구현하였습니다.
  - `getById`라는 네이밍도 있지만 이미 `JpaRepository`에 해당 메서드가 구현되어 있어서 명시적으로 도메인 이름을 붙여주었습니다. 
- 댓글 수정/삭제 API 변경 필요
  - 현재 댓글은 룸ID 과 상관없이 ID가 올라갑니다. (룸ID 별로 댓글 테이블이 있는 형태가 아닌 하나의 댓글 테이블로 존재하기 때문)
  - 따라서 룸을 수정/삭제할 때 다른 룸의 댓글일 경우가 존재하지 않습니다.
    - ex) 1번 룸의 10번 댓글 - 2번 룸의 10번 댓글이 존재할 수 없습니다.
  - 따라서 기존 댓글을 수정/삭제 시 룸 ID가 필요가 없어졌기 때문에 API 수정이 필요해 보입니다.  
     - 단, 의미적으로는"`/rooms/{roomId}/comments/{commentId}` _라는 API가 룸에 종속된 댓글이다_ "가 더 맞는것 같습니다.
     - 이부분은 백엔드 크루 간 회의를 해보면 좋겠습니다.