### PR TITLE
스크랩 해제 후 메인으로 돌아오면 아이콘 변경되지 않는 버그 해결

### DIFF
--- a/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomActivity.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomActivity.kt
@@ -15,6 +15,7 @@ import com.digginroom.digginroom.feature.room.roominfo.RoomInfoDialog
 import com.digginroom.digginroom.feature.scrap.activity.ScrapListActivity
 import com.digginroom.digginroom.feature.tutorial.TutorialFragment
 import com.digginroom.digginroom.model.RoomsModel
+import com.digginroom.digginroom.model.mapper.RoomMapper.toDomain
 import com.digginroom.digginroom.util.getSerializable
 import com.dygames.androiddi.ViewModelDependencyInjector.injectViewModel
 import com.dygames.roompager.PagingOrientation
@@ -67,11 +68,14 @@ class RoomActivity : AppCompatActivity() {
             when (it) {
                 is RoomState.Error -> Unit
                 RoomState.Loading -> Unit
-                is RoomState.Success -> roomPagerAdapter.setData(it.rooms)
+                is RoomState.Success -> {
+                    roomPagerAdapter.setData(it.rooms)
+                }
             }
         }
+        val rooms = intent.getSerializable<RoomsModel>(KEY_ROOMS)?.value ?: emptyList()
         roomPagerAdapter.setData(
-            intent.getSerializable<RoomsModel>(KEY_ROOMS)?.value ?: emptyList()
+            rooms
         )
         binding.roomRoomPager.setRoomLoadable(roomPagerAdapter.rooms.isEmpty())
         binding.roomRoomPager.setOrientation(
@@ -87,6 +91,8 @@ class RoomActivity : AppCompatActivity() {
             repeat(3) {
                 roomViewModel.findNext()
             }
+        } else {
+            roomViewModel.setRooms(rooms.map { it.toDomain() })
         }
     }
 

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomActivity.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomActivity.kt
@@ -1,11 +1,8 @@
 package com.digginroom.digginroom.feature.room
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.result.ActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.commit
@@ -17,7 +14,6 @@ import com.digginroom.digginroom.feature.room.customview.roomplayer.RoomState
 import com.digginroom.digginroom.feature.room.roominfo.RoomInfoDialog
 import com.digginroom.digginroom.feature.scrap.activity.ScrapListActivity
 import com.digginroom.digginroom.feature.tutorial.TutorialFragment
-import com.digginroom.digginroom.model.RoomModel
 import com.digginroom.digginroom.model.RoomsModel
 import com.digginroom.digginroom.util.getSerializable
 import com.dygames.androiddi.ViewModelDependencyInjector.injectViewModel
@@ -25,15 +21,6 @@ import com.dygames.roompager.PagingOrientation
 
 class RoomActivity : AppCompatActivity() {
     private lateinit var binding: ActivityRoomBinding
-    private val activityResultLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                val scrappedRooms: List<RoomModel> =
-                    result.data?.getSerializable<RoomsModel>(KEY_SCRAPPED_ROOMS)?.value
-                        ?: emptyList()
-                roomViewModel.updateScrappedRooms(scrappedRooms)
-            }
-        }
 
     private val roomViewModel: RoomViewModel by lazy {
         ViewModelProvider(
@@ -53,7 +40,7 @@ class RoomActivity : AppCompatActivity() {
             }, openInfo = { track ->
                 roomInfoDialog.show(supportFragmentManager, track)
             }, openScrap = {
-                activityResultLauncher.launch(Intent(this, ScrapListActivity::class.java))
+                ScrapListActivity.start(this)
             }, scrap = { id ->
                 roomViewModel.postScrap(id)
             }, unScrap = { id ->
@@ -111,6 +98,7 @@ class RoomActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         roomPagerAdapter.play()
+        roomViewModel.findScrappedRooms()
     }
 
     private fun navigateToTutorial(tutorialCompleted: Boolean) {
@@ -132,7 +120,6 @@ class RoomActivity : AppCompatActivity() {
         private const val KEY_INITIAL_POSITION = "initial_position"
         private const val KEY_PAGING_ORIENTATION = "paging_orientation"
         private const val KEY_TUTORIAL_COMPLETED = "tutorial_completed"
-        private const val KEY_SCRAPPED_ROOMS = "scrapped_rooms"
         fun start(context: Context) {
             val intent = Intent(context, RoomActivity::class.java)
             context.startActivity(intent)
@@ -160,13 +147,6 @@ class RoomActivity : AppCompatActivity() {
                 putExtra(KEY_TUTORIAL_COMPLETED, tutorialCompleted)
             }
             context.startActivity(intent)
-        }
-
-        fun getIntentForResultWithScrappedRooms(
-            context: Context,
-            scrappedRooms: RoomsModel
-        ): Intent = Intent(context, RoomActivity::class.java).apply {
-            putExtra(KEY_SCRAPPED_ROOMS, scrappedRooms)
         }
     }
 }

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomViewModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.digginroom.digginroom.feature.room.customview.roomplayer.RoomState
+import com.digginroom.digginroom.model.RoomModel
 import com.digginroom.digginroom.model.mapper.RoomMapper.toModel
 import com.digginroom.digginroom.model.room.Room
 import com.digginroom.digginroom.repository.RoomRepository
@@ -66,6 +67,19 @@ class RoomViewModel @Keep constructor(
                     }
                 }
             }.onFailure {}
+        }
+    }
+
+    fun updateScrappedRooms(
+        renewalScrappedRooms: List<RoomModel>
+    ) {
+        rooms.filter { it.isScrapped }.forEach { scrappedRoom ->
+            if (renewalScrappedRooms.none { it.roomId == scrappedRoom.roomId }) {
+                val index = rooms.indexOfFirst { it.roomId == scrappedRoom.roomId }
+                rooms[index] =
+                    scrappedRoom.copy(isScrapped = false, scrapCount = scrappedRoom.scrapCount - 1)
+                _cachedRoom.value = RoomState.Success(rooms.map { it.toModel() })
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomViewModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/room/RoomViewModel.kt
@@ -70,7 +70,15 @@ class RoomViewModel @Keep constructor(
         }
     }
 
-    fun updateScrappedRooms(
+    fun findScrappedRooms() {
+        viewModelScope.launch {
+            roomRepository.findScrapped().onSuccess { rooms ->
+                updateScrappedRooms(rooms.map { it.toModel() })
+            }.onFailure { }
+        }
+    }
+
+    private fun updateScrappedRooms(
         renewalScrappedRooms: List<RoomModel>
     ) {
         rooms.filter { it.isScrapped }.forEach { scrappedRoom ->

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/scrap/activity/ScrapListActivity.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/scrap/activity/ScrapListActivity.kt
@@ -3,14 +3,17 @@ package com.digginroom.digginroom.feature.scrap.activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import com.digginroom.digginroom.R
 import com.digginroom.digginroom.databinding.ActivityScrapBinding
+import com.digginroom.digginroom.feature.room.RoomActivity
 import com.digginroom.digginroom.feature.scrap.adapter.ScrapAdapter
 import com.digginroom.digginroom.feature.scrap.navigator.DefaultScrapNavigator
 import com.digginroom.digginroom.feature.scrap.viewmodel.ScrapViewModel
+import com.digginroom.digginroom.model.RoomsModel
 import com.dygames.androiddi.ViewModelDependencyInjector.injectViewModel
 
 class ScrapListActivity : AppCompatActivity() {
@@ -22,6 +25,7 @@ class ScrapListActivity : AppCompatActivity() {
             injectViewModel<ScrapViewModel>()
         )[ScrapViewModel::class.java]
     }
+    private lateinit var scrappedRooms: RoomsModel
 
     override fun onResume() {
         super.onResume()
@@ -31,8 +35,9 @@ class ScrapListActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         initScrapBinding()
+        initScrappedRoomsObserver()
+        initBackPressedCallback()
     }
 
     private fun initScrapBinding() {
@@ -45,6 +50,27 @@ class ScrapListActivity : AppCompatActivity() {
                     it.navigateToScrapRoomView = DefaultScrapNavigator(this)::navigate
                     it.scrapIvBack.setOnClickListener { finish() }
                 }
+    }
+
+    private fun initScrappedRoomsObserver() {
+        scrapViewModel.scrappedRooms.observe(this) {
+            scrappedRooms = RoomsModel(it)
+        }
+    }
+
+    private fun initBackPressedCallback() {
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    setResult(
+                        RESULT_OK,
+                        RoomActivity.getIntentForResultWithScrappedRooms(this@ScrapListActivity, scrappedRooms)
+                    )
+                    if (!isFinishing) finish()
+                }
+            }
+        )
     }
 
     companion object {

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/scrap/activity/ScrapListActivity.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/scrap/activity/ScrapListActivity.kt
@@ -3,17 +3,14 @@ package com.digginroom.digginroom.feature.scrap.activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import com.digginroom.digginroom.R
 import com.digginroom.digginroom.databinding.ActivityScrapBinding
-import com.digginroom.digginroom.feature.room.RoomActivity
 import com.digginroom.digginroom.feature.scrap.adapter.ScrapAdapter
 import com.digginroom.digginroom.feature.scrap.navigator.DefaultScrapNavigator
 import com.digginroom.digginroom.feature.scrap.viewmodel.ScrapViewModel
-import com.digginroom.digginroom.model.RoomsModel
 import com.dygames.androiddi.ViewModelDependencyInjector.injectViewModel
 
 class ScrapListActivity : AppCompatActivity() {
@@ -25,7 +22,6 @@ class ScrapListActivity : AppCompatActivity() {
             injectViewModel<ScrapViewModel>()
         )[ScrapViewModel::class.java]
     }
-    private lateinit var scrappedRooms: RoomsModel
 
     override fun onResume() {
         super.onResume()
@@ -36,8 +32,6 @@ class ScrapListActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initScrapBinding()
-        initScrappedRoomsObserver()
-        initBackPressedCallback()
     }
 
     private fun initScrapBinding() {
@@ -50,27 +44,6 @@ class ScrapListActivity : AppCompatActivity() {
                     it.navigateToScrapRoomView = DefaultScrapNavigator(this)::navigate
                     it.scrapIvBack.setOnClickListener { finish() }
                 }
-    }
-
-    private fun initScrappedRoomsObserver() {
-        scrapViewModel.scrappedRooms.observe(this) {
-            scrappedRooms = RoomsModel(it)
-        }
-    }
-
-    private fun initBackPressedCallback() {
-        onBackPressedDispatcher.addCallback(
-            this,
-            object : OnBackPressedCallback(true) {
-                override fun handleOnBackPressed() {
-                    setResult(
-                        RESULT_OK,
-                        RoomActivity.getIntentForResultWithScrappedRooms(this@ScrapListActivity, scrappedRooms)
-                    )
-                    if (!isFinishing) finish()
-                }
-            }
-        )
     }
 
     companion object {


### PR DESCRIPTION
## 관련 이슈번호
- #329 

## 작업 사항
스크랩 화면에서 스크랩을 해제하는 경우 룸 화면으로 돌아왔을 때 반영이 되지 않는 버그가 있었습니다
그래서 스크랩 화면에서 업데이트된 스크랩 정보를 룸 화면의 이미 캐싱되어있는 룸들에 어떻게 적용해줄까 고민하다가 
[registerForActivityResult](https://developer.android.com/training/basics/intents/result) 를 이용하여 ScrapListActivity -> RoomActivity 로 돌아올 때 최신 스크랩 룸들 결과를 가지고 돌아오도록 구현하였습니다!

이 방법이 괜찮은건지 모르겠어서 혹시 더 나은 방법 아신다면 말씀해주세요~!

## 기타 사항
<br/>
