### PR TITLE
feat: 로그아웃 기능을 구현한다.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.DigginRoom"
         tools:targetApi="31">
-     
+        <activity
+            android:name=".feature.setting.SettingActivity"
+            android:exported="true" />
         <activity
             android:name=".feature.splash.SplashActivity"
             android:exported="true">
@@ -25,20 +27,23 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".feature.genretaste.GenreTasteActivity"
             android:exported="true" />
         <activity
             android:name=".feature.login.LoginActivity"
             android:exported="true" />
-        <activity android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:host="oauth"
+
+                <data
+                    android:host="oauth"
                     android:scheme="kakao${kakaoNativeKey}" />
             </intent-filter>
         </activity>

--- a/android/app/src/main/java/com/digginroom/digginroom/data/datasource/local/TokenLocalDataSource.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/data/datasource/local/TokenLocalDataSource.kt
@@ -18,6 +18,12 @@ class TokenLocalDataSource @Keep constructor(
         }
     }
 
+    fun delete() {
+        tokenPreference.edit {
+            remove(KEY_TOKEN)
+        }
+    }
+
     fun fetch(): String =
         tokenPreference.getString(KEY_TOKEN, "") ?: ""
 

--- a/android/app/src/main/java/com/digginroom/digginroom/data/repository/DefaultTokenRepository.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/data/repository/DefaultTokenRepository.kt
@@ -19,6 +19,13 @@ class DefaultTokenRepository @Keep constructor(
             }
         }
 
+    override suspend fun delete(): LogResult<Unit> =
+        withContext(Dispatchers.IO) {
+            logRunCatching {
+                tokenLocalDataSource.delete()
+            }
+        }
+
     override suspend fun fetch(): LogResult<String> =
         withContext(Dispatchers.IO) {
             logRunCatching {

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingActivity.kt
@@ -1,0 +1,33 @@
+package com.digginroom.digginroom.feature.setting
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import com.digginroom.digginroom.R
+import com.digginroom.digginroom.databinding.ActivitySettingBinding
+import com.digginroom.digginroom.model.SettingCategoryModel
+
+class SettingActivity : AppCompatActivity() {
+
+    lateinit var binding: ActivitySettingBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        initSettingBinding()
+        initSettingView()
+    }
+
+    private fun initSettingBinding() {
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_setting)
+    }
+
+    private fun initSettingView() {
+        binding.settingRvSetttingCategory.adapter = SettingCategoryAdapter(
+            categories = listOf(
+                SettingCategoryModel.Account,
+                SettingCategoryModel.Etc
+            )
+        )
+    }
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingActivity.kt
@@ -1,33 +1,94 @@
 package com.digginroom.digginroom.feature.setting
 
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.ViewModelProvider
 import com.digginroom.digginroom.R
 import com.digginroom.digginroom.databinding.ActivitySettingBinding
+import com.digginroom.digginroom.feature.login.LoginActivity
+import com.digginroom.digginroom.model.SettingCategoryDetailModel
 import com.digginroom.digginroom.model.SettingCategoryModel
+import com.dygames.androiddi.ViewModelDependencyInjector.injectViewModel
 
 class SettingActivity : AppCompatActivity() {
 
-    lateinit var binding: ActivitySettingBinding
+    private lateinit var binding: ActivitySettingBinding
+    private lateinit var logoutConfirmDialog: AlertDialog
+    private val settingViewModel: SettingViewModel by lazy {
+        ViewModelProvider(
+            this,
+            injectViewModel<SettingViewModel>()
+        )[SettingViewModel::class.java]
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         initSettingBinding()
         initSettingView()
+        initLogoutDialog()
+        initSettingObserver()
     }
 
     private fun initSettingBinding() {
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_setting)
+        binding =
+            DataBindingUtil.setContentView<ActivitySettingBinding>(this, R.layout.activity_setting)
+                .also {
+                    it.lifecycleOwner = this
+                    it.viewModel = settingViewModel
+                }
     }
 
     private fun initSettingView() {
         binding.settingRvSetttingCategory.adapter = SettingCategoryAdapter(
             categories = listOf(
-                SettingCategoryModel.Account,
-                SettingCategoryModel.Etc
+                SettingCategoryModel.Account(
+                    listOf(
+                        SettingCategoryDetailModel(
+                            description = R.string.common_logout,
+                            descriptionImg = R.drawable.ic_logout,
+                            invoke = settingViewModel::startLogout
+                        )
+                    )
+                ),
+                SettingCategoryModel.Etc(
+                    listOf(
+                        SettingCategoryDetailModel(
+                            description = R.string.common_feedback,
+                            descriptionImg = R.drawable.ic_logout
+                        )
+                    )
+                )
             )
         )
+    }
+
+    private fun initLogoutDialog() {
+        logoutConfirmDialog = AlertDialog.Builder(this)
+            .apply {
+                setMessage(LOGOUT_CONFIRM_MESSAGE)
+                    .setPositiveButton(getString(R.string.common_yes)) { _, _ ->
+                        settingViewModel.logout()
+                    }.setNegativeButton(getString(R.string.common_no)) { _, _ ->
+                    }
+            }.create()
+    }
+
+    private fun initSettingObserver() {
+        settingViewModel.state.observe(this) {
+            when (settingViewModel.state.value) {
+                SettingState.Logout.InProgress -> logoutConfirmDialog.show()
+
+                SettingState.Logout.Done -> LoginActivity.start(this)
+
+                else -> {}
+            }
+        }
+    }
+
+    companion object {
+        private const val LOGOUT_CONFIRM_MESSAGE = "정말 로그아웃하시겠습니까?"
     }
 }

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingCategoryAdapter.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingCategoryAdapter.kt
@@ -1,0 +1,20 @@
+package com.digginroom.digginroom.feature.setting
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.digginroom.digginroom.model.SettingCategoryModel
+
+class SettingCategoryAdapter(
+    private val categories: List<SettingCategoryModel>
+) : RecyclerView.Adapter<SettingViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SettingViewHolder {
+        return SettingViewHolder.of(parent)
+    }
+
+    override fun onBindViewHolder(holder: SettingViewHolder, position: Int) {
+        holder.bind(categories[position])
+    }
+
+    override fun getItemCount(): Int = categories.size
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingCategoryDetailViewHolder.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingCategoryDetailViewHolder.kt
@@ -1,0 +1,26 @@
+package com.digginroom.digginroom.feature.setting
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.digginroom.digginroom.databinding.ItemSettingDetailBinding
+import com.digginroom.digginroom.model.SettingCategoryDetailModel
+
+class SettingCategoryDetailViewHolder(
+    private val binding: ItemSettingDetailBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(detail: SettingCategoryDetailModel) {
+        binding.detail = detail
+    }
+
+    companion object {
+
+        fun of(parent: ViewGroup): SettingCategoryDetailViewHolder {
+            val layoutInflater = LayoutInflater.from(parent.context)
+            val binding = ItemSettingDetailBinding.inflate(layoutInflater, parent, false)
+
+            return SettingCategoryDetailViewHolder(binding)
+        }
+    }
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingCategoryDetailsAdapter.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingCategoryDetailsAdapter.kt
@@ -1,0 +1,22 @@
+package com.digginroom.digginroom.feature.setting
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.digginroom.digginroom.model.SettingCategoryDetailModel
+
+class SettingCategoryDetailsAdapter(private val details: List<SettingCategoryDetailModel>) :
+    RecyclerView.Adapter<SettingCategoryDetailViewHolder>() {
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): SettingCategoryDetailViewHolder {
+        return SettingCategoryDetailViewHolder.of(parent)
+    }
+
+    override fun onBindViewHolder(holder: SettingCategoryDetailViewHolder, position: Int) {
+        holder.bind(details[position])
+    }
+
+    override fun getItemCount(): Int = details.size
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingState.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingState.kt
@@ -1,0 +1,16 @@
+package com.digginroom.digginroom.feature.setting
+
+sealed interface SettingState {
+
+    sealed interface Logout : SettingState {
+
+        object InProgress : Logout
+
+        object Done : Logout
+    }
+
+    object Cancel : SettingState
+
+    // todo: 피드백 기능에 대한 상태
+    object Feedback : SettingState
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingViewHolder.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingViewHolder.kt
@@ -11,8 +11,10 @@ class SettingViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(category: SettingCategoryModel) {
-        binding.description = category.description
-        binding.settingRvCategoryDetails.adapter = SettingCategoryDetailsAdapter(category.details)
+        with(binding) {
+            description = category.description
+            settingRvCategoryDetails.adapter = SettingCategoryDetailsAdapter(category.details)
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingViewHolder.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingViewHolder.kt
@@ -1,0 +1,27 @@
+package com.digginroom.digginroom.feature.setting
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.digginroom.digginroom.databinding.ItemSettingBinding
+import com.digginroom.digginroom.model.SettingCategoryModel
+
+class SettingViewHolder(
+    private val binding: ItemSettingBinding
+) : RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(category: SettingCategoryModel) {
+        binding.description = category.description
+        binding.settingRvCategoryDetails.adapter = SettingCategoryDetailsAdapter(category.details)
+    }
+
+    companion object {
+
+        fun of(parent: ViewGroup): SettingViewHolder {
+            val layoutInflater = LayoutInflater.from(parent.context)
+            val binding = ItemSettingBinding.inflate(layoutInflater, parent, false)
+
+            return SettingViewHolder(binding)
+        }
+    }
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/setting/SettingViewModel.kt
@@ -1,0 +1,37 @@
+package com.digginroom.digginroom.feature.setting
+
+import androidx.annotation.Keep
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.digginroom.digginroom.repository.TokenRepository
+import com.dygames.di.annotation.NotCaching
+import kotlinx.coroutines.launch
+
+@NotCaching
+class SettingViewModel @Keep constructor(
+    private val tokenRepository: TokenRepository
+) : ViewModel() {
+
+    private val _state: MutableLiveData<SettingState> = MutableLiveData()
+    val state: LiveData<SettingState>
+        get() = _state
+
+    fun startLogout() {
+        _state.value = SettingState.Logout.InProgress
+    }
+
+    fun logout() {
+        viewModelScope.launch {
+            tokenRepository.delete()
+                .onSuccess {
+                    _state.value = SettingState.Logout.Done
+                }.onFailure {}
+        }
+    }
+
+    fun cancel() {
+        _state.value = SettingState.Cancel
+    }
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryDetailModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryDetailModel.kt
@@ -1,0 +1,11 @@
+package com.digginroom.digginroom.model
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+
+data class SettingCategoryDetailModel(
+    @StringRes
+    val description: Int,
+    @DrawableRes
+    val descriptionImg: Int
+)

--- a/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryDetailModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryDetailModel.kt
@@ -7,5 +7,6 @@ data class SettingCategoryDetailModel(
     @StringRes
     val description: Int,
     @DrawableRes
-    val descriptionImg: Int
+    val descriptionImg: Int,
+    var invoke: (() -> Unit)? = null
 )

--- a/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryModel.kt
@@ -1,0 +1,42 @@
+package com.digginroom.digginroom.model
+
+import androidx.annotation.StringRes
+import com.digginroom.digginroom.R
+
+interface SettingCategoryModel {
+
+    val description: Int
+    val details: List<SettingCategoryDetailModel>
+
+    object Account : SettingCategoryModel {
+
+        @StringRes
+        override val description: Int = R.string.common_account
+
+        override val details: List<SettingCategoryDetailModel> =
+            listOf(
+                SettingCategoryDetailModel(
+                    description = R.string.common_login,
+                    descriptionImg = R.drawable.ic_logout
+                ),
+                SettingCategoryDetailModel(
+                    description = R.string.common_withdrawal,
+                    descriptionImg = R.drawable.ic_withdrawal
+                )
+            )
+    }
+
+    object Etc : SettingCategoryModel {
+
+        @StringRes
+        override val description: Int = R.string.common_etc
+
+        override val details: List<SettingCategoryDetailModel> =
+            listOf(
+                SettingCategoryDetailModel(
+                    description = R.string.common_feedback,
+                    descriptionImg = R.drawable.ic_logout
+                )
+            )
+    }
+}

--- a/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryModel.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/model/SettingCategoryModel.kt
@@ -3,40 +3,23 @@ package com.digginroom.digginroom.model
 import androidx.annotation.StringRes
 import com.digginroom.digginroom.R
 
-interface SettingCategoryModel {
+sealed class SettingCategoryModel(val details: List<SettingCategoryDetailModel>) {
 
-    val description: Int
-    val details: List<SettingCategoryDetailModel>
+    abstract val description: Int
 
-    object Account : SettingCategoryModel {
+    class Account(
+        details: List<SettingCategoryDetailModel>
+    ) : SettingCategoryModel(details) {
 
         @StringRes
         override val description: Int = R.string.common_account
-
-        override val details: List<SettingCategoryDetailModel> =
-            listOf(
-                SettingCategoryDetailModel(
-                    description = R.string.common_login,
-                    descriptionImg = R.drawable.ic_logout
-                ),
-                SettingCategoryDetailModel(
-                    description = R.string.common_withdrawal,
-                    descriptionImg = R.drawable.ic_withdrawal
-                )
-            )
     }
 
-    object Etc : SettingCategoryModel {
+    class Etc(
+        details: List<SettingCategoryDetailModel>
+    ) : SettingCategoryModel(details) {
 
         @StringRes
         override val description: Int = R.string.common_etc
-
-        override val details: List<SettingCategoryDetailModel> =
-            listOf(
-                SettingCategoryDetailModel(
-                    description = R.string.common_feedback,
-                    descriptionImg = R.drawable.ic_logout
-                )
-            )
     }
 }

--- a/android/app/src/main/res/drawable/ic_logout.xml
+++ b/android/app/src/main/res/drawable/ic_logout.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#FFFFFF" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17,7l-1.41,1.41L18.17,11H8v2h10.17l-2.58,2.58L17,17l5,-5zM4,5h8V3H4c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h8v-2H4V5z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_withdrawal.xml
+++ b/android/app/src/main/res/drawable/ic_withdrawal.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,24c-3.26,0 -6.19,-1.99 -7.4,-5.02l-3.03,-7.61C2.26,10.58 3,9.79 3.81,10.05l0.79,0.26c0.56,0.18 1.02,0.61 1.24,1.16L7.25,15H8V3.25C8,2.56 8.56,2 9.25,2s1.25,0.56 1.25,1.25V12h1V1.25C11.5,0.56 12.06,0 12.75,0S14,0.56 14,1.25V12h1V2.75c0,-0.69 0.56,-1.25 1.25,-1.25c0.69,0 1.25,0.56 1.25,1.25V12h1V5.75c0,-0.69 0.56,-1.25 1.25,-1.25S21,5.06 21,5.75V16C21,20.42 17.42,24 13,24z"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_setting.xml
+++ b/android/app/src/main/res/layout/activity_setting.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout>
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.digginroom.digginroom.feature.setting.SettingViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
@@ -13,6 +20,7 @@
             android:id="@+id/setting_iv_back"
             android:layout_width="40dp"
             android:layout_height="40dp"
+            android:onClick="@{() -> viewModel.cancel()}"
             android:layout_marginStart="8dp"
             android:layout_marginTop="20dp"
             android:contentDescription="@string/common_back_button_description"

--- a/android/app/src/main/res/layout/activity_setting.xml
+++ b/android/app/src/main/res/layout/activity_setting.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#110B2E"
+        tools:context=".feature.setting.SettingActivity">
+
+        <ImageView
+            android:id="@+id/setting_iv_back"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="20dp"
+            android:contentDescription="@string/common_back_button_description"
+            android:src="@drawable/ic_arrow_left"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/setting_tv_setting"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/setting_setting_private"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/setting_rv_settting_category"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="60dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/setting_tv_setting"
+            tools:listitem="@layout/item_setting" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_setting.xml
+++ b/android/app/src/main/res/layout/item_setting.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="description"
+            type="int" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#110B2E">
+
+        <TextView
+            android:id="@+id/setting_tv_category_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="15dp"
+            android:text="@{description}"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="계정" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/setting_rv_category_details"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:orientation="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/setting_tv_category_title"
+            tools:itemCount="2"
+            tools:listitem="@layout/item_setting_detail" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_setting_detail.xml
+++ b/android/app/src/main/res/layout/item_setting_detail.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+
+        <variable
+            name="detail"
+            type="com.digginroom.digginroom.model.SettingCategoryDetailModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:background="#110B2E">
+
+        <ImageView
+            android:id="@+id/setting_iv_description"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_margin="10dp"
+            app:src="@{detail.descriptionImg}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@+id/setting_tv_description"
+            app:layout_constraintHorizontal_weight="0.07"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_weight="3"
+            tools:src="@drawable/ic_logout" />
+
+        <TextView
+            android:id="@+id/setting_tv_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="@{detail.description}"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="@id/setting_iv_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_weight="0.93"
+            app:layout_constraintStart_toEndOf="@id/setting_iv_description"
+            app:layout_constraintTop_toTopOf="@id/setting_iv_description"
+            tools:text="로그아웃" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/android/app/src/main/res/layout/item_setting_detail.xml
+++ b/android/app/src/main/res/layout/item_setting_detail.xml
@@ -13,6 +13,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:onClick="@{() -> detail.invoke.invoke()}"
         tools:background="#110B2E">
 
         <ImageView

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,11 +3,16 @@
 
     <string name="common_login">로그인</string>
     <string name="common_join">회원가입</string>
+    <string name="common_logout">로그아웃</string>
+    <string name="common_withdrawal">회원 탈퇴</string>
+    <string name="common_feedback">피드백</string>
     <string name="common_id">아이디</string>
     <string name="common_password">비밀번호</string>
     <string name="common_thumbnail">https://img.youtube.com/vi/%s/0.jpg</string>
     <string name="common_back_button_description">image_of_back_button</string>
     <string name="common_diggin_room_logo">Diggin\' Room Logo</string>
+    <string name="common_account">계정</string>
+    <string name="common_etc">기타 기능</string>
 
     <string name="login_guest_login">게스트 로그인</string>
     <string name="login_forgot_account">로그인 정보를 잊으셨나요?</string>
@@ -57,4 +62,5 @@
     <string name="track_genre">장르: %s</string>
     <string name="edit_comment">수정</string>
     <string name="delete_comment">삭제</string>
+    <string name="setting_setting_private">설정 및 개인정보</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="common_diggin_room_logo">Diggin\' Room Logo</string>
     <string name="common_account">계정</string>
     <string name="common_etc">기타 기능</string>
+    <string name="common_yes">네</string>
+    <string name="common_no">아니오</string>
 
     <string name="login_guest_login">게스트 로그인</string>
     <string name="login_forgot_account">로그인 정보를 잊으셨나요?</string>
@@ -63,4 +65,5 @@
     <string name="edit_comment">수정</string>
     <string name="delete_comment">삭제</string>
     <string name="setting_setting_private">설정 및 개인정보</string>
+    <string name="dialog_confirm_confirm_logout">로그아웃 하시겠습니까?</string>
 </resources>

--- a/android/domain/src/main/java/com/digginroom/digginroom/repository/TokenRepository.kt
+++ b/android/domain/src/main/java/com/digginroom/digginroom/repository/TokenRepository.kt
@@ -6,5 +6,7 @@ interface TokenRepository {
 
     suspend fun save(token: String): LogResult<Unit>
 
+    suspend fun delete(): LogResult<Unit>
+
     suspend fun fetch(): LogResult<String>
 }


### PR DESCRIPTION
## 관련 이슈번호
- #336 

## 작업 사항
로그아웃 기능 구현 완료
![image](https://github.com/woowacourse-teams/2023-diggin-room/assets/88770426/ba02c416-6e5e-4fec-9f1e-331feaae753a)

## 기타 사항
현재 설정화면에 들어가는 설정 종류들은 이런 계층 구조를 가지고 있습니다.
* SettingCategoryModel
  * SettingDetailCategoryModel
리사이클러뷰도 SettingCategoryModel에 대한 리사이클러뷰가 있고 해당 리사이클러뷰의 뷰홀더 안에 SettingDetailCategoryModel들이 표시되는 리사이클러뷰가 존재합니다.

ex) 
* 계정
  * 로그아웃
  * 회원탈퇴(추가 예정)
* 기타 기능
  * 피드백

각 SettingDetailCategoryModel에 해당하는 이벤트가 있을 것인데 이 이벤트를 어떤 방식으로 전해주어야 좋은 구조가 나올지 잘 모르겠습니다. 만약 SettingLisetener로 리사이클러뷰에 전해주게 된다면 각 이벤트에 따라 Model에 매핑하는 과정도 번거로울 것 같아서 현재는 Model을 초기화하는 시점에서 이벤트를 Model의 property로 전해주고 있습니다. 좋은 의견이 있으시면 말해주세요~
  

