### PR TITLE
재생목록 추출 기능 개발

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -44,4 +44,7 @@ jobs:
           -DDEV_DATASOURCE_URL=${{ secrets.DEV_DATASOURCE_URL }} \
           -DDEV_DATASOURCE_USERNAME=${{ secrets.DEV_DATASOURCE_USERNAME }} \
           -DDEV_DATASOURCE_PASSWORD=${{ secrets.DEV_DATASOURCE_PASSWORD }} \
+          -DCLIENT_ID=${{ secrets.CLIENT_ID }} \
+          -DCLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
+          -DREDIRECT_URI=${{ secrets.REDIRECT_URI }} \
           DigginRoom-0.0.1-SNAPSHOT.jar &

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -44,4 +44,7 @@ jobs:
           -DPROD_DATASOURCE_URL=${{ secrets.PROD_DATASOURCE_URL }} \
           -DPROD_DATASOURCE_USERNAME=${{ secrets.PROD_DATASOURCE_USERNAME }} \
           -DPROD_DATASOURCE_PASSWORD=${{ secrets.PROD_DATASOURCE_PASSWORD }} \
+          -DCLIENT_ID=${{ secrets.CLIENT_ID }} \
+          -DCLIENT_SECRET=${{ secrets.CLIENT_SECRET }} \
+          -DREDIRECT_URI=${{ secrets.REDIRECT_URI }} \
           DigginRoom-0.0.1-SNAPSHOT.jar &

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework:spring-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/backend/src/main/java/com/digginroom/digginroom/DigginRoomApplication.java
+++ b/backend/src/main/java/com/digginroom/digginroom/DigginRoomApplication.java
@@ -2,10 +2,12 @@ package com.digginroom.digginroom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class DigginRoomApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/digginroom/digginroom/exception/PlayListException.java
+++ b/backend/src/main/java/com/digginroom/digginroom/exception/PlayListException.java
@@ -1,0 +1,16 @@
+package com.digginroom.digginroom.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class PlayListException extends DigginRoomException {
+
+    public PlayListException(final String message, final HttpStatus httpStatus) {
+        super(message, httpStatus);
+    }
+
+    public static class PlaylistCreateException extends PlayListException {
+        public PlaylistCreateException() {
+            super("플레이 리스트를 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/controller/PlayListController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/controller/PlayListController.java
@@ -1,0 +1,24 @@
+package com.digginroom.digginroom.playlist.controller;
+
+import com.digginroom.digginroom.playlist.service.GoogleAuthService;
+import com.digginroom.digginroom.playlist.service.dto.PlayListRequest;
+import com.digginroom.digginroom.playlist.service.dto.PlayListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+@RequiredArgsConstructor
+public class PlayListController {
+
+    private final GoogleAuthService googleAuthService;
+
+    @PostMapping("/playList")
+    public ResponseEntity<PlayListResponse> makePlayList(
+            @RequestBody PlayListRequest playListRequest
+    ) {
+        return ResponseEntity.ok().body(googleAuthService.makePlayList(playListRequest));
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/controller/PlayListController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/controller/PlayListController.java
@@ -16,9 +16,7 @@ public class PlayListController {
     private final PlayListService playListService;
 
     @PostMapping("/playList")
-    public ResponseEntity<PlayListResponse> makePlayList(
-            @RequestBody PlayListRequest playListRequest
-    ) {
+    public ResponseEntity<PlayListResponse> makePlayList(@RequestBody PlayListRequest playListRequest) {
         return ResponseEntity.ok().body(playListService.makePlayList(playListRequest));
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/controller/PlayListController.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/controller/PlayListController.java
@@ -1,6 +1,6 @@
 package com.digginroom.digginroom.playlist.controller;
 
-import com.digginroom.digginroom.playlist.service.GoogleAuthService;
+import com.digginroom.digginroom.playlist.service.PlayListService;
 import com.digginroom.digginroom.playlist.service.dto.PlayListRequest;
 import com.digginroom.digginroom.playlist.service.dto.PlayListResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +13,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 @RequiredArgsConstructor
 public class PlayListController {
 
-    private final GoogleAuthService googleAuthService;
+    private final PlayListService playListService;
 
     @PostMapping("/playList")
     public ResponseEntity<PlayListResponse> makePlayList(
             @RequestBody PlayListRequest playListRequest
     ) {
-        return ResponseEntity.ok().body(googleAuthService.makePlayList(playListRequest));
+        return ResponseEntity.ok().body(playListService.makePlayList(playListRequest));
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GoogleAccessTokenClient.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GoogleAccessTokenClient.java
@@ -1,0 +1,23 @@
+package com.digginroom.digginroom.playlist.infra;
+
+import com.digginroom.digginroom.playlist.infra.dto.GoogleAccessTokenRequest;
+import com.digginroom.digginroom.playlist.infra.dto.GoogleAccessTokenResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class GoogleAccessTokenClient {
+
+    private WebClient webClient = WebClient.builder()
+            .baseUrl("https://oauth2.googleapis.com")
+            .build();
+
+    public GoogleAccessTokenResponse getGoogleToken(final GoogleAccessTokenRequest request) {
+        return webClient.post()
+                .uri("/token")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(GoogleAccessTokenResponse.class)
+                .block();
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GoogleOAuthConfig.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GoogleOAuthConfig.java
@@ -1,14 +1,12 @@
 package com.digginroom.digginroom.playlist.infra;
 
-import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Data
 @ConfigurationProperties(prefix = "oauth.google")
-public class GoogleOAuthConfig {
-
-    private String clientId;
-    private String clientSecret;
-    private String redirectUri;
-    private String grantType;
+public record GoogleOAuthConfig(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String grantType
+) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GoogleOAuthConfig.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GoogleOAuthConfig.java
@@ -1,0 +1,14 @@
+package com.digginroom.digginroom.playlist.infra;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "oauth.google")
+public class GoogleOAuthConfig {
+
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String grantType;
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GooglePlayListClient.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GooglePlayListClient.java
@@ -1,5 +1,6 @@
 package com.digginroom.digginroom.playlist.infra;
 
+import com.digginroom.digginroom.exception.PlayListException.PlaylistCreateException;
 import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListRequest;
 import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListResponse;
 import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest;
@@ -21,9 +22,15 @@ public class GooglePlayListClient {
                 .uri("/playlists?part=id,snippet")
                 .headers(headers -> headers.setBearerAuth(authorization))
                 .bodyValue(request)
-                .retrieve()
-                .bodyToMono(YouTubePlayListResponse.class)
+                .exchangeToMono(this::generateYoutubePlayListResponse)
                 .block();
+    }
+
+    public Mono<YouTubePlayListResponse> generateYoutubePlayListResponse(final ClientResponse response) {
+        if (response.statusCode().equals(HttpStatus.OK)) {
+            return response.bodyToMono(YouTubePlayListResponse.class);
+        }
+        throw new PlaylistCreateException();
     }
 
     public Integer insertPlayListItems(final String authorization, final YoutubePlayListItemRequest request) {

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GooglePlayListClient.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GooglePlayListClient.java
@@ -1,0 +1,44 @@
+package com.digginroom.digginroom.playlist.infra;
+
+import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListRequest;
+import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListResponse;
+import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class GooglePlayListClient {
+
+    private WebClient webClient = WebClient.builder()
+            .baseUrl("https://www.googleapis.com/youtube/v3/")
+            .build();
+
+    public YouTubePlayListResponse createPlayList(final String authorization, final YouTubePlayListRequest request) {
+        return webClient.post()
+                .uri("/playlists?part=id,snippet")
+                .headers(headers -> headers.setBearerAuth(authorization))
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(YouTubePlayListResponse.class)
+                .block();
+    }
+
+    public Integer insertPlayListItems(String authorization, YoutubePlayListItemRequest request) {
+        return webClient.post()
+                .uri("/playlistItems?part=contentDetails,id,snippet,status")
+                .headers(headers -> headers.setBearerAuth(authorization))
+                .bodyValue(request)
+                .exchangeToMono(this::exchangeSuccessCount)
+                .block();
+    }
+
+    private Mono<Integer> exchangeSuccessCount(final ClientResponse response) {
+        if (response.statusCode().equals(HttpStatus.OK)) {
+            return Mono.just(1);
+        }
+        return Mono.just(0);
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GooglePlayListClient.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/GooglePlayListClient.java
@@ -26,7 +26,7 @@ public class GooglePlayListClient {
                 .block();
     }
 
-    public Integer insertPlayListItems(String authorization, YoutubePlayListItemRequest request) {
+    public Integer insertPlayListItems(final String authorization, final YoutubePlayListItemRequest request) {
         return webClient.post()
                 .uri("/playlistItems?part=contentDetails,id,snippet,status")
                 .headers(headers -> headers.setBearerAuth(authorization))

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenRequest.java
@@ -1,0 +1,18 @@
+package com.digginroom.digginroom.playlist.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record GoogleAccessTokenRequest(
+        @JsonProperty("client_id")
+        String clientId,
+        @JsonProperty("client_secret")
+        String clientSecret,
+        String code,
+        @JsonProperty("redirect_uri")
+        String redirectUri,
+        @JsonProperty("grant_type")
+        String grantType
+) {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenRequest.java
@@ -1,18 +1,16 @@
 package com.digginroom.digginroom.playlist.infra.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record GoogleAccessTokenRequest(
-        @JsonProperty("client_id")
         String clientId,
-        @JsonProperty("client_secret")
         String clientSecret,
         String code,
-        @JsonProperty("redirect_uri")
         String redirectUri,
-        @JsonProperty("grant_type")
         String grantType
 ) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenResponse.java
@@ -1,9 +1,10 @@
 package com.digginroom.digginroom.playlist.infra.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record GoogleAccessTokenResponse(
-        @JsonProperty("access_token")
         String accessToken
 ) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.digginroom.digginroom.playlist.infra.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleAccessTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken
+) {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/GoogleAccessTokenResponse.java
@@ -4,7 +4,5 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record GoogleAccessTokenResponse(
-        String accessToken
-) {
+public record GoogleAccessTokenResponse(String accessToken) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListRequest.java
@@ -1,10 +1,6 @@
 package com.digginroom.digginroom.playlist.infra.dto;
 
-public record YouTubePlayListRequest(
-        Snippet snippet
-) {
-    public record Snippet(
-            String title
-    ) {
+public record YouTubePlayListRequest(Snippet snippet) {
+    public record Snippet(String title) {
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListRequest.java
@@ -1,0 +1,10 @@
+package com.digginroom.digginroom.playlist.infra.dto;
+
+public record YouTubePlayListRequest(
+        Snippet snippet
+) {
+    public record Snippet(
+            String title
+    ) {
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListResponse.java
@@ -1,0 +1,6 @@
+package com.digginroom.digginroom.playlist.infra.dto;
+
+public record YouTubePlayListResponse(
+        String id
+) {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YouTubePlayListResponse.java
@@ -1,6 +1,4 @@
 package com.digginroom.digginroom.playlist.infra.dto;
 
-public record YouTubePlayListResponse(
-        String id
-) {
+public record YouTubePlayListResponse(String id) {
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YoutubePlayListItemRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YoutubePlayListItemRequest.java
@@ -1,0 +1,17 @@
+package com.digginroom.digginroom.playlist.infra.dto;
+
+public record YoutubePlayListItemRequest(
+        Snippet snippet
+) {
+
+    public record Snippet(
+            String playlistId,
+            ResourceId resourceId
+    ) {
+        public record ResourceId(
+                String kind,
+                String videoId
+        ) {
+        }
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YoutubePlayListItemRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YoutubePlayListItemRequest.java
@@ -1,9 +1,19 @@
 package com.digginroom.digginroom.playlist.infra.dto;
 
+import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest.Snippet.ResourceId;
+
 public record YoutubePlayListItemRequest(Snippet snippet) {
 
     public record Snippet(String playlistId, ResourceId resourceId) {
         public record ResourceId(String kind, String videoId) {
         }
+    }
+
+    public static YoutubePlayListItemRequest of(final String playListId, final String videoId) {
+        return new YoutubePlayListItemRequest(
+                new YoutubePlayListItemRequest.Snippet(playListId,
+                        new ResourceId("youtube#video", videoId)
+                )
+        );
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YoutubePlayListItemRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/infra/dto/YoutubePlayListItemRequest.java
@@ -1,17 +1,9 @@
 package com.digginroom.digginroom.playlist.infra.dto;
 
-public record YoutubePlayListItemRequest(
-        Snippet snippet
-) {
+public record YoutubePlayListItemRequest(Snippet snippet) {
 
-    public record Snippet(
-            String playlistId,
-            ResourceId resourceId
-    ) {
-        public record ResourceId(
-                String kind,
-                String videoId
-        ) {
+    public record Snippet(String playlistId, ResourceId resourceId) {
+        public record ResourceId(String kind, String videoId) {
         }
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/service/GoogleAuthService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/service/GoogleAuthService.java
@@ -1,0 +1,76 @@
+package com.digginroom.digginroom.playlist.service;
+
+import com.digginroom.digginroom.playlist.infra.GoogleAccessTokenClient;
+import com.digginroom.digginroom.playlist.infra.GoogleOAuthConfig;
+import com.digginroom.digginroom.playlist.infra.GooglePlayListClient;
+import com.digginroom.digginroom.playlist.infra.dto.GoogleAccessTokenRequest;
+import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListRequest;
+import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListRequest.Snippet;
+import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest;
+import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest.Snippet.ResourceId;
+import com.digginroom.digginroom.playlist.service.dto.PlayListRequest;
+import com.digginroom.digginroom.playlist.service.dto.PlayListResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleAuthService {
+
+    private final GoogleOAuthConfig googleOAuthConfig;
+    private final GoogleAccessTokenClient googleAccessTokenClient;
+    private final GooglePlayListClient playListClient;
+
+    public PlayListResponse makePlayList(final PlayListRequest request) {
+        String accessToken = getAccessToken(request.code());
+        String playListId = createPlayList(accessToken, request);
+        Integer success = insertPlayListItems(accessToken, playListId, request);
+        return new PlayListResponse(calculateRequestCount(request), success);
+    }
+
+    private String getAccessToken(final String code) {
+        GoogleAccessTokenRequest request = GoogleAccessTokenRequest.builder()
+                .redirectUri(googleOAuthConfig.getRedirectUri())
+                .clientId(googleOAuthConfig.getClientId())
+                .clientSecret(googleOAuthConfig.getClientSecret())
+                .grantType(googleOAuthConfig.getGrantType())
+                .code(code)
+                .build();
+
+        return googleAccessTokenClient.getGoogleToken(request).accessToken();
+    }
+
+    private String createPlayList(final String authorization, final PlayListRequest request) {
+        YouTubePlayListRequest youTubePlayListRequest = new YouTubePlayListRequest(
+                new Snippet(request.title())
+        );
+        return playListClient.createPlayList(authorization, youTubePlayListRequest).id();
+    }
+
+    private Integer insertPlayListItems(
+            final String authorization,
+            final String playListId,
+            final PlayListRequest request
+    ) {
+        List<String> videoIds = request.videoIds();
+        return videoIds.stream()
+                .map(videoId -> playListClient.insertPlayListItems(authorization, toRequest(playListId, videoId)))
+                .reduce(0, Integer::sum);
+    }
+
+    private YoutubePlayListItemRequest toRequest(final String playListId, final String videoId) {
+        return new YoutubePlayListItemRequest(
+                new YoutubePlayListItemRequest.Snippet(playListId,
+                        new ResourceId("youtube#video", videoId)
+                )
+        );
+    }
+
+    private int calculateRequestCount(final PlayListRequest request) {
+        long count = request.videoIds()
+                .stream()
+                .count();
+        return (int) count;
+    }
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/service/PlayListService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/service/PlayListService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class GoogleAuthService {
+public class PlayListService {
 
     private final GoogleOAuthConfig googleOAuthConfig;
     private final GoogleAccessTokenClient googleAccessTokenClient;
@@ -31,10 +31,10 @@ public class GoogleAuthService {
 
     private String getAccessToken(final String code) {
         GoogleAccessTokenRequest request = GoogleAccessTokenRequest.builder()
-                .redirectUri(googleOAuthConfig.getRedirectUri())
-                .clientId(googleOAuthConfig.getClientId())
-                .clientSecret(googleOAuthConfig.getClientSecret())
-                .grantType(googleOAuthConfig.getGrantType())
+                .redirectUri(googleOAuthConfig.redirectUri())
+                .clientId(googleOAuthConfig.clientId())
+                .clientSecret(googleOAuthConfig.clientSecret())
+                .grantType(googleOAuthConfig.grantType())
                 .code(code)
                 .build();
 
@@ -68,9 +68,6 @@ public class GoogleAuthService {
     }
 
     private int calculateRequestCount(final PlayListRequest request) {
-        long count = request.videoIds()
-                .stream()
-                .count();
-        return (int) count;
+        return request.videoIds().size();
     }
 }

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/service/PlayListService.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/service/PlayListService.java
@@ -7,7 +7,6 @@ import com.digginroom.digginroom.playlist.infra.dto.GoogleAccessTokenRequest;
 import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListRequest;
 import com.digginroom.digginroom.playlist.infra.dto.YouTubePlayListRequest.Snippet;
 import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest;
-import com.digginroom.digginroom.playlist.infra.dto.YoutubePlayListItemRequest.Snippet.ResourceId;
 import com.digginroom.digginroom.playlist.service.dto.PlayListRequest;
 import com.digginroom.digginroom.playlist.service.dto.PlayListResponse;
 import java.util.List;
@@ -55,16 +54,11 @@ public class PlayListService {
     ) {
         List<String> videoIds = request.videoIds();
         return videoIds.stream()
-                .map(videoId -> playListClient.insertPlayListItems(authorization, toRequest(playListId, videoId)))
-                .reduce(0, Integer::sum);
-    }
-
-    private YoutubePlayListItemRequest toRequest(final String playListId, final String videoId) {
-        return new YoutubePlayListItemRequest(
-                new YoutubePlayListItemRequest.Snippet(playListId,
-                        new ResourceId("youtube#video", videoId)
+                .map(videoId -> playListClient.insertPlayListItems(
+                        authorization,
+                        YoutubePlayListItemRequest.of(playListId, videoId))
                 )
-        );
+                .reduce(0, Integer::sum);
     }
 
     private int calculateRequestCount(final PlayListRequest request) {

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/service/dto/PlayListRequest.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/service/dto/PlayListRequest.java
@@ -1,0 +1,10 @@
+package com.digginroom.digginroom.playlist.service.dto;
+
+import java.util.List;
+
+public record PlayListRequest(
+        String title,
+        List<String> videoIds,
+        String code
+) {
+}

--- a/backend/src/main/java/com/digginroom/digginroom/playlist/service/dto/PlayListResponse.java
+++ b/backend/src/main/java/com/digginroom/digginroom/playlist/service/dto/PlayListResponse.java
@@ -1,0 +1,7 @@
+package com.digginroom.digginroom.playlist.service.dto;
+
+public record PlayListResponse(
+        int count,
+        int success
+) {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,3 +21,9 @@ springdoc:
     path: /docs
   cache:
     disabled: true
+oauth:
+  google:
+    clientId: ${CLIENT_ID}
+    clientSecret: ${CLIENT_SECRET}
+    redirectUri: ${REDIRECT_URI}
+    grantType: authorization_code


### PR DESCRIPTION
## 관련 이슈번호
#364

## 작업 사항
- insertPlayListItems 요청이 오래걸려서 비동기로 요청을 보내려고 시도했으나 
유튜브 측에서 insert 작업도중에 새로운 insert 작업이 들어오면 409를 리턴해서 동기로 작업했습니다.

- webclient를 사용한 이유는 일단 비동기 처리를 염두해두고 사용한거긴한데, spring에서도 webclient를 권장해서 유지했습니다
> NOTE: As of 5.0 this class is in maintenance mode, with only minor requests for changes and bugs to be accepted going forward. Please, consider using the org.springframework.web.reactive.client.WebClient which has a more modern API and supports sync, async, and streaming scenarios.
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html

## 기타 사항
infra와 service 패키지 코드를 중점적으로 보면 좋을것같고
설정 파일들 실수가 있는지 한번씩 확인하면 좋을듯합니다.