### PR TITLE
댓글창에 다크모드 적용 및 뷰 성능 개선

### DIFF
--- a/android/app/src/main/java/com/digginroom/digginroom/feature/room/comment/dialog/BottomFixedItemBottomSheetDialog.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/room/comment/dialog/BottomFixedItemBottomSheetDialog.kt
@@ -45,7 +45,7 @@ abstract class BottomFixedItemBottomSheetDialog : BottomSheetDialogFragment() {
 
     private fun View.makeFullSize() {
         this.layoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT
-        requestLayout()
+        invalidate()
     }
 
     private fun ViewGroup.addStickyView(view: View) {

--- a/android/app/src/main/java/com/digginroom/digginroom/feature/room/comment/dialog/CommentDialog.kt
+++ b/android/app/src/main/java/com/digginroom/digginroom/feature/room/comment/dialog/CommentDialog.kt
@@ -38,6 +38,7 @@ class CommentDialog : BottomFixedItemBottomSheetDialog() {
         dialogBinding.lifecycleOwner = this
         dialogBinding.commentViewModel = commentViewModel
         dialogBinding.adapter = CommentAdapter(::showCommentMenuDialog)
+        dialogBinding.dialogCommentRecyclerViewComment.setHasFixedSize(true)
     }
 
     private fun initBottomPlacedItemBinding() {

--- a/android/app/src/main/res/layout/dialog_comment_bottom_placed_item_layout.xml
+++ b/android/app/src/main/res/layout/dialog_comment_bottom_placed_item_layout.xml
@@ -27,7 +27,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white">
+        android:background="?android:attr/colorBackground">
 
         <View
             android:id="@+id/dialog_comment_sticky_item_view_separator"
@@ -49,8 +49,8 @@
             android:inputType="text"
             android:paddingHorizontal="16dp"
             android:paddingVertical="10dp"
-            app:cursorIndex="@{currentComment}"
             android:text="@={currentComment}"
+            app:cursorIndex="@{currentComment}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/dialog_comment_sticky_btn_send"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/app/src/main/res/layout/dialog_comment_layout.xml
+++ b/android/app/src/main/res/layout/dialog_comment_layout.xml
@@ -45,7 +45,7 @@
             android:layout_marginTop="10dp"
             android:gravity="center"
             android:text="@string/dialog_comment_comment"
-            android:textColor="@color/black"
+            android:textColor="@color/room_info_text_color"
             android:textSize="16sp"
             android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/dialog_comment_view_banner" />

--- a/android/app/src/main/res/layout/dialog_comment_layout.xml
+++ b/android/app/src/main/res/layout/dialog_comment_layout.xml
@@ -50,29 +50,21 @@
             android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@id/dialog_comment_view_banner" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/dialog_comment_recyclerView_comment"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:adapter="@{adapter}"
+            android:orientation="vertical"
+            android:paddingTop="18dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/dialog_comment_tv_banner">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/dialog_comment_recyclerView_comment"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:adapter="@{adapter}"
-                android:orientation="vertical"
-                android:paddingTop="18dp"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:responseState="@{commentViewModel.commentResponseUiState}"
-                app:visible="@{commentViewModel.commentResponseUiState}"
-                tools:itemCount="200" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintTop_toBottomOf="@id/dialog_comment_tv_banner"
+            app:responseState="@{commentViewModel.commentResponseUiState}"
+            app:visible="@{commentViewModel.commentResponseUiState}"
+            tools:itemCount="200" />
 
         <TextView
             android:id="@+id/textView"

--- a/android/app/src/main/res/layout/item_room_info.xml
+++ b/android/app/src/main/res/layout/item_room_info.xml
@@ -20,11 +20,19 @@
 
     <merge>
 
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="-20dp"
+            android:background="@drawable/room_info_gradient"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/room_info_scrap_toggle" />
+
         <ImageButton
             android:id="@+id/room_info_ib_scrap"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_marginTop="22dp"
+            android:layout_marginTop="26dp"
             android:layout_marginEnd="16dp"
             android:background="?attr/selectableItemBackground"
             android:cropToPadding="true"
@@ -70,7 +78,7 @@
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:layout_marginEnd="16dp"
-            android:layout_marginBottom="4dp"
+            android:layout_marginBottom="2dp"
             android:cropToPadding="true"
             android:scaleType="centerInside"
             app:layout_constraintBottom_toTopOf="@+id/room_info_tv_scrap_count"
@@ -84,7 +92,7 @@
             android:id="@+id/room_info_tv_scrap_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="22dp"
+            android:layout_marginBottom="20dp"
             android:shadowColor="#8C000000"
             android:shadowRadius="5"
             android:text="@{scrapCountFormatter.convert(roomInfoUiState.roomModel.scrapCount)}"
@@ -137,4 +145,5 @@
             app:layout_constraintBottom_toBottomOf="@id/room_info_tv_title_artist"
             app:layout_constraintEnd_toEndOf="parent" />
     </merge>
+
 </layout>


### PR DESCRIPTION
## 관련 이슈번호
- #399 

## 작업 사항
- editText 와 다이얼로그 텍스트에 다크모드를 적용
- item_room_info 레이아웃 누락된 요소(그림자 및 마진값) 적용
- 뷰 계층 구조를 정리
- 필요한 RecyclerView 에 setHasFixedSize 를 적용

<img src="https://github.com/woowacourse-teams/2023-diggin-room/assets/63198157/363fb8bc-515f-48eb-aa64-c4187e24fce0" width="350"/>

## 기타 사항
<br/>
