### PR TITLE
fix: binding parameter log를 확인할 수 없는 문제 해결

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -5,15 +5,15 @@ spring:
   datasource:
     generate-unique-name: false
   jpa:
-    show-sql: true
     properties:
       hibernate:
         format_sql: true
+        highlight_sql: true
         ddl-auto: create
     defer-datasource-initialization: true
   flyway:
     enabled: false
 logging:
   level:
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -10,6 +10,7 @@ spring:
         format_sql: true
         highlight_sql: true
         ddl-auto: create
+        use_sql_comments: false
     defer-datasource-initialization: true
   flyway:
     enabled: false


### PR DESCRIPTION
## 관련 이슈번호
<br/> #415 

## 작업 사항
binding parameter log를 확인할 수 없는 문제 해결

## 기타 사항
```yaml
logging:
  level:
    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
spring:
  jpa:
    properties:
      hibernate:
        format_sql: true
    show-sql: true
```

이전 미션에서 위와 같이 application.yml을 구성했을때 

```yaml
Hibernate: 
    select
        ordertable0_.id as id1_5_0_,
        ordertable0_.empty as empty2_5_0_,
        ordertable0_.number_of_guests as number_o3_5_0_,
        ordertable0_.table_group_id as table_gr4_5_0_,
        tablegroup1_.id as id1_7_1_,
        tablegroup1_.created_date as created_2_7_1_ 
    from
        order_table ordertable0_ 
    left outer join
        table_group tablegroup1_ 
            on ordertable0_.table_group_id=tablegroup1_.id 
    where
        ordertable0_.id=?
2023-10-24 14:18:22.765 TRACE 66299 --- [    Test worker] o.h.type.descriptor.sql.BasicBinder      : binding parameter [1] as [BIGINT] - [9]
```

위와 같이 binding parameter를 모두 확인할 수 있었다.

하지만 현재 프로젝트에서는 binding parameter는 확인할 수없었다.

이유는 SpringBoot 3 부터는 Hibernate 6 버전을 사용하는데

Hibernate 6 BasicBinder가 Rename 되었다.

```yaml
spring:
  h2:
    console:
      enabled: true
  datasource:
    generate-unique-name: false
  jpa:
    properties:
      hibernate:
        format_sql: true
        highlight_sql: true
        ddl-auto: create
    defer-datasource-initialization: true
  flyway:
    enabled: false
logging:
  level:
    org.hibernate.SQL: debug
    org.hibernate.orm.jdbc.bind: trace
```

![image](https://github.com/woowacourse-teams/2023-diggin-room/assets/83541246/437828d0-4146-4c82-bf04-05c8993b8d28)


https://github.com/spring-projects/spring-boot/issues/36640

https://docs.jboss.org/hibernate/orm/6.0/logging/logging.html
